### PR TITLE
1337 improve lambda error handling

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -77,7 +77,7 @@ class DocumentsController < AuthenticatedController
   def update_summary
     if @document.summary.nil?
       @document.update(
-        summary: @document.inference_summary
+        summary: @document.inference_summary!
       )
     end
     render json: {

--- a/python_components/summary/lambda_function.py
+++ b/python_components/summary/lambda_function.py
@@ -7,28 +7,32 @@ import boto3
 import pdf2image
 import llm
 
+
 def get_config():
-    with open('config.json', 'r') as f:
+    with open("config.json", "r") as f:
         return json.load(f)
 
+
 def get_models():
-    with open('models.json', 'r') as f:
+    with open("models.json", "r") as f:
         return json.load(f)
+
 
 def get_supported_models(local_mode):
     if local_mode:
         config = get_config()
         return {
-            config['active_model']: {
-                'key': config['key']
+            config["active_model"]: {
+                "key": config["key"]
             }
         }
     else:
         return get_models()
 
+
 # Create and provide a very simple logger implementation.
-logger = logging.getLogger('experiment_utility')
-formatter = logging.Formatter('%(asctime)s: %(message)s')
+logger = logging.getLogger("experiment_utility")
+formatter = logging.Formatter("%(asctime)s: %(message)s")
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
 ch.setLevel(logging.DEBUG)
@@ -40,36 +44,36 @@ def get_secret(secret_name: str, local_mode: bool) -> str:
     if local_mode:
         session = boto3.session.Session()
         client = session.client(
-            service_name='secretsmanager',
-            aws_access_key_id='no secrets',
-            aws_secret_access_key='for you here',
-            endpoint_url='http://localstack:4566',
-            region_name='us-east-1',
+            service_name="secretsmanager",
+            aws_access_key_id="no secrets",
+            aws_secret_access_key="for you here",
+            endpoint_url="http://localstack:4566",
+            region_name="us-east-1",
         )
     else:
         session = boto3.session.Session()
-        client = session.client(service_name='secretsmanager')
+        client = session.client(service_name="secretsmanager")
 
     response = client.get_secret_value(SecretId=secret_name)
-    return response['SecretString']
+    return response["SecretString"]
 
 
 def get_file(url: str, output_path: str) -> str:
     file_name = os.path.basename(url)
-    local_path = f'{output_path}/{file_name}'
+    local_path = f"{output_path}/{file_name}"
     urllib.request.urlretrieve(url, local_path)
     return local_path
 
 
 def pdf_to_attachments(pdf_path: str, output_path: str, page_limit: int) -> list:
-    images = pdf2image.convert_from_path(pdf_path, fmt='jpg')
+    images = pdf2image.convert_from_path(pdf_path, fmt="jpg")
     attachments = []
     for page, image in enumerate(images):
         if 0 < page_limit - 1 < page:
             break
-        page_path = f'{output_path}/page-{page}.jpg'
+        page_path = f"{output_path}/page-{page}.jpg"
         image.save(page_path)
-        attachments.append(llm.Attachment(path=page_path, type='image/jpeg'))
+        attachments.append(llm.Attachment(path=page_path, type="image/jpeg"))
     return attachments
 
 
@@ -84,37 +88,53 @@ def get_summary(model_name: str, api_key: str, attachments: list) -> str:
 
 
 def handler(event, context):
-    for required_key in ('model_name', 'document_url', 'page_limit'):
-        if required_key not in event:
-            raise ValueError(f'Function called without required parameter, {required_key}.')
+    try:
+        for required_key in ("model_name", "document_url", "page_limit"):
+            if required_key not in event:
+                raise ValueError(
+                    f"Function called without required parameter, {required_key}."
+                )
 
-    local_mode = os.environ.get('ASAP_LOCAL_MODE', False)
-    supported_models = get_supported_models(local_mode)
+        local_mode = os.environ.get("ASAP_LOCAL_MODE", False)
+        supported_models = get_supported_models(local_mode)
 
-    if event['model_name'] not in supported_models.keys():
-        supported_model_list = ','.join(supported_models.keys())
-        raise ValueError(f'Unsupported model: {event["model_name"]}. Options are: {supported_model_list}')
+        if event["model_name"] not in supported_models.keys():
+            supported_model_list = ",".join(supported_models.keys())
+            raise ValueError(
+                f"Unsupported model: {event['model_name']}. Options are: {supported_model_list}"
+            )
 
-    if local_mode:
-        api_key = supported_models[event['model_name']]['key']
-        config = get_config()
-        page_limit = config['page_limit'] if event['page_limit'] == 0 else event['page_limit']
-    else:
-        api_key = get_secret(supported_models[event['model_name']]['key'], local_mode)
-        page_limit = 'unlimited' if event['page_limit'] == 0 else event['page_limit']
+        if local_mode:
+            api_key = supported_models[event["model_name"]]["key"]
+            config = get_config()
+            page_limit = (
+                config["page_limit"] if event["page_limit"] == 0 else event["page_limit"]
+            )
+        else:
+            api_key = get_secret(supported_models[event["model_name"]]["key"], local_mode)
+            page_limit = "unlimited" if event["page_limit"] == 0 else event["page_limit"]
 
-    logger.info(f'Page limit set to {page_limit}.')
-    logger.info(f'Attempting to fetch document: {event["document_url"]}')
+        logger.info(f"Page limit set to {page_limit}.")
+        logger.info(f"Attempting to fetch document: {event["document_url"]}")
 
-    # Download file locally.
-    local_path = get_file(event['document_url'], './data')
+        # Download file locally.
+        local_path = get_file(event["document_url"], "./data")
 
-    # Convert to images.
-    logger.info('Converting to images!')
-    attachments = pdf_to_attachments(local_path, './data', event['page_limit'])
-    num_attachments = len(attachments)
-    logger.info(f'Document has {num_attachments} pages.')
+        # Convert to images.
+        logger.info("Converting to images!")
+        attachments = pdf_to_attachments(local_path, "./data", event["page_limit"])
+        num_attachments = len(attachments)
+        logger.info(f"Document has {num_attachments} pages.")
 
-    # Send images off to our friend.
-    logger.info(f'Summarizing with {event["model_name"]}...')
-    return get_summary(event['model_name'], api_key, attachments)
+        # Send images off to our friend.
+        logger.info(f"Summarizing with {event['model_name']}...")
+        summary = get_summary(event["model_name"], api_key, attachments)
+    except Exception as e:
+        return {
+            "statusCode": 500,
+            "body": str(e),
+        }
+    return {
+        "statusCode": 200,
+        "body": summary,
+    }


### PR DESCRIPTION
Currently the document model's inference_summary method saves full error JSON from the Lambda if it fails. This JSON string does not get properly quote wrapped before DB insertion. Later when we call `document.summary&.undump` to unescape quotes in the AI response, the error JSON produces an error:

```
invalid dumped string; not wrapped with '"' nor '"...".force_encoding("...")' form
```

This prevents our modal from showing any content. We don't want the errors saved to the summary field to begin with. Let's solve this bug, but not recording the JSON response at all.

Currently our local Lambda simulations don't return a non-200 HTTP status code when they fail. I'm not sure whether this will be different in production. For now, let's explicitly return a status code from our handler. This will allow us not to save the summary when there was an error.