### PR TITLE
1337 ready lambdas for aws

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 
 gem "bcrypt", "~> 3.1"
 gem "aws-sdk-s3", "~> 1.182"  # For S3 versioning support
+gem "aws-sdk-secretsmanager"
 
 # API and Documentation
 gem "grape", "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
+    aws-sdk-secretsmanager (1.113.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
@@ -493,6 +496,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1.182)
+  aws-sdk-secretsmanager
   bcrypt (~> 3.1)
   better_errors (~> 2.10)
   bootsnap

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -1,22 +1,63 @@
 class ConfigurationsController < ApplicationController
+
+  GOOGLE_API_SECRET_NAME = "asap-pdf/production/GOOGLE_AI_KEY"
+  ANTHROPIC_API_SECRET_NAME = "asap-pdf/production/ANTHROPIC_KEY"
+
+  def initialize
+    super
+    @secret_manager = Aws::SecretsManager::Client.new(
+      endpoint: "http://localhost:4566",
+      access_key_id: "none",
+      secret_access_key: "none",
+      region: "us-east-1"
+    )
+  rescue NetworkingError => e
+    @secret_manager = nil
+  end
+
   def edit
-    @config = JSON.parse(File.read(Rails.root.join("python_components", "summary", "config.json")))
-    models_data = JSON.parse(File.read(Rails.root.join("python_components", "summary", "models.json")))
-    @models = models_data.keys
+    @config = {
+      "localstack_not_reachable": false,
+    }
+    response = self.get_secret!(GOOGLE_API_SECRET_NAME)
+    @config["google_ai_api_key"] = response.secret_string if response.present?
+    response = self.get_secret!(ANTHROPIC_API_SECRET_NAME)
+    @config["anthropic_api_key"] = response.secret_string if response.present?
+
+  rescue Seahorse::Client::NetworkingError
+    @config["localstack_not_reachable"] = true
+
   end
 
   def update
-    config_path = Rails.root.join("python_components", "summary", "config.json")
-    config = JSON.parse(File.read(config_path))
-
-    config["active_model"] = params[:config][:active_model]
-    config["key"] = params[:config][:key]
-    config["page_limit"] = params[:config][:page_limit].to_i
-    config["prompt"] = params[:config][:prompt]
-
-    File.write(config_path, JSON.pretty_generate(config))
+    self.set_secret!(GOOGLE_API_SECRET_NAME, params[:config][:google_ai_api_key])
+    self.set_secret!(ANTHROPIC_API_SECRET_NAME, params[:config][:anthropic_api_key])
     redirect_to edit_configuration_path, notice: "Configuration updated successfully"
   rescue => e
     redirect_to edit_configuration_path, alert: "Error updating configuration: #{e.message}"
+  end
+
+  private
+
+  def get_secret!(secret_name)
+    secret = @secret_manager.get_secret_value({
+                                                secret_id: secret_name
+                                              })
+  rescue Aws::SecretsManager::Errors::ResourceNotFoundException
+    secret = nil
+  end
+
+  def set_secret!(secret_name, value)
+    if self.get_secret!(secret_name).nil?
+      @secret_manager.create_secret({
+                              name: secret_name,
+                              secret_string: value
+                            })
+    else
+      @secret_manager.update_secret({
+                              secret_id: secret_name,
+                              secret_string: value
+                            })
+    end
   end
 end

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -1,5 +1,4 @@
 class ConfigurationsController < ApplicationController
-
   GOOGLE_API_SECRET_NAME = "asap-pdf/production/GOOGLE_AI_KEY"
   ANTHROPIC_API_SECRET_NAME = "asap-pdf/production/ANTHROPIC_KEY"
 
@@ -11,27 +10,25 @@ class ConfigurationsController < ApplicationController
       secret_access_key: "none",
       region: "us-east-1"
     )
-  rescue NetworkingError => e
+  rescue NetworkingError
     @secret_manager = nil
   end
 
   def edit
     @config = {
-      "localstack_not_reachable": false,
+      localstack_not_reachable: false
     }
-    response = self.get_secret!(GOOGLE_API_SECRET_NAME)
+    response = get_secret!(GOOGLE_API_SECRET_NAME)
     @config["google_ai_api_key"] = response.secret_string if response.present?
-    response = self.get_secret!(ANTHROPIC_API_SECRET_NAME)
+    response = get_secret!(ANTHROPIC_API_SECRET_NAME)
     @config["anthropic_api_key"] = response.secret_string if response.present?
-
   rescue Seahorse::Client::NetworkingError
     @config["localstack_not_reachable"] = true
-
   end
 
   def update
-    self.set_secret!(GOOGLE_API_SECRET_NAME, params[:config][:google_ai_api_key])
-    self.set_secret!(ANTHROPIC_API_SECRET_NAME, params[:config][:anthropic_api_key])
+    set_secret!(GOOGLE_API_SECRET_NAME, params[:config][:google_ai_api_key])
+    set_secret!(ANTHROPIC_API_SECRET_NAME, params[:config][:anthropic_api_key])
     redirect_to edit_configuration_path, notice: "Configuration updated successfully"
   rescue => e
     redirect_to edit_configuration_path, alert: "Error updating configuration: #{e.message}"
@@ -40,24 +37,24 @@ class ConfigurationsController < ApplicationController
   private
 
   def get_secret!(secret_name)
-    secret = @secret_manager.get_secret_value({
-                                                secret_id: secret_name
-                                              })
+    @secret_manager.get_secret_value({
+      secret_id: secret_name
+    })
   rescue Aws::SecretsManager::Errors::ResourceNotFoundException
-    secret = nil
+    nil
   end
 
   def set_secret!(secret_name, value)
-    if self.get_secret!(secret_name).nil?
+    if get_secret!(secret_name).nil?
       @secret_manager.create_secret({
-                              name: secret_name,
-                              secret_string: value
-                            })
+        name: secret_name,
+        secret_string: value
+      })
     else
       @secret_manager.update_secret({
-                              secret_id: secret_name,
-                              secret_string: value
-                            })
+        secret_id: secret_name,
+        secret_string: value
+      })
     end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -171,7 +171,7 @@ class Document < ApplicationRecord
         model_name: "gemini-2.0-pro-exp-02-05",
         documents: [{id: id, title: file_name, url: url, purpose: document_category}],
         page_limit: 7,
-        asap_endpoint: "http://host.docker.internal:3000/api/documents/inference",
+        asap_endpoint: "http://host.docker.internal:3000/api/documents/inference"
       }.to_json
       begin
         response = RestClient.post(endpoint_url, payload, {content_type: :json, accept: :json})

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -170,7 +170,8 @@ class Document < ApplicationRecord
       payload = {
         model_name: "gemini-2.0-pro-exp-02-05",
         documents: [{id: id, title: file_name, url: url, purpose: document_category}],
-        page_limit: 7
+        page_limit: 7,
+        asap_endpoint: "http://host.docker.internal:3000/api/documents/inference",
       }.to_json
       begin
         response = RestClient.post(endpoint_url, payload, {content_type: :json, accept: :json})

--- a/app/views/configurations/edit.html.erb
+++ b/app/views/configurations/edit.html.erb
@@ -5,63 +5,66 @@
         <i class="fas fa-wand-magic-sparkles mr-2"></i>
         AI Configuration Settings
       </h2>
-      <%= form_with(scope: :config, url: configuration_path, method: :patch) do |f| %>
-        <div class="space-y-6">
-          <div class="form-control w-full">
-            <%= f.label :active_model, "Active Model", class: "label" %>
-            <div class="mt-2">
-              <%= f.select :active_model,
-                  options_for_select(@models, @config["active_model"]),
-                  {},
-                  class: "select select-bordered w-full" %>
-            </div>
-          </div>
-          <div class="form-control w-full">
-            <%= f.label :key, "API Key", class: "label" %>
-            <div class="mt-2">
-              <div class="join w-full" data-controller="password-toggle">
-                <%= f.password_field :key,
-                    value: @config["key"],
-                    autocomplete: "new-password",
-                    class: "input input-bordered join-item w-full font-mono",
-                    data: { password_toggle_target: "input" } %>
-                <button type="button" class="btn join-item" data-action="click->password-toggle#toggle">
-                  <i class="fas fa-eye" data-password-toggle-target="icon"></i>
-                </button>
+      <% if Rails.env == "production" %>
+        <p>The configuration items provided on this page are not for the production environment. Please set secrets via
+          configuration or directly in AWS.</p>
+      <% elsif @config["localstack_not_reachable"] == true %>
+        <p>Localstack is not running or is not reachable. Please be sure to run docker compose from the application
+          root.</p>
+      <% else %>
+        <%= form_with(scope: :config, url: configuration_path, method: :patch) do |f| %>
+          <div class="space-y-6">
+            <div class="form-control w-full">
+              <%= f.label :google_ai_api_key, "Google AI API Key", class: "label" %>
+              <div class="mt-2">
+                <div class="join w-full" data-controller="password-toggle">
+                  <%= f.password_field :google_ai_api_key,
+                                       value: @config["google_ai_api_key"],
+                                       autocomplete: "new-password",
+                                       class: "input input-bordered join-item w-full font-mono",
+                                       data: { password_toggle_target: "input" } %>
+                  <button type="button" class="btn join-item" data-action="click->password-toggle#toggle">
+                    <i class="fas fa-eye" data-password-toggle-target="icon"></i>
+                  </button>
+                </div>
+                <div class="mt-2 text-sm text-gray-600">
+                  <p>Need a Google Gemini API key?
+                    <%= link_to "Generate one here", "https://aistudio.google.com/app/apikey",
+                                target: "_blank",
+                                class: "link link-primary" %>
+                  </p>
+                </div>
               </div>
-              <div class="mt-2 text-sm text-gray-600">
-                <p>Need a Google Gemini API key?
-                  <%= link_to "Generate one here", "https://aistudio.google.com/app/apikey",
-                      target: "_blank",
-                      class: "link link-primary" %>
-                </p>
+            </div>
+            <div class="form-control w-full">
+              <%= f.label :anthropic_api_key, "Anthropic API Key", class: "label" %>
+              <div class="mt-2">
+                <div class="join w-full" data-controller="password-toggle">
+                  <%= f.password_field :anthropic_api_key,
+                                       value: @config["anthropic_api_key"],
+                                       autocomplete: "new-password",
+                                       class: "input input-bordered join-item w-full font-mono",
+                                       data: { password_toggle_target: "input" } %>
+                  <button type="button" class="btn join-item" data-action="click->password-toggle#toggle">
+                    <i class="fas fa-eye" data-password-toggle-target="icon"></i>
+                  </button>
+                </div>
+                <div class="mt-2 text-sm text-gray-600">
+                  <p>Need an Anthropic API key?
+                    <%= link_to "Generate one here", "https://docs.anthropic.com/en/api/getting-started",
+                                target: "_blank",
+                                class: "link link-primary" %>
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="form-control w-full">
-            <%= f.label :page_limit, "Page Limit", class: "label" %>
-            <div class="mt-2">
-              <%= f.select :page_limit,
-                  options_for_select((1..20).to_a, @config["page_limit"]),
-                  {},
-                  class: "select select-bordered w-full" %>
+            <div class="card-actions justify-end mt-6">
+              <%= f.submit "Save Changes",
+                           class: "btn btn-primary" %>
             </div>
-          </div>
-          <div class="form-control w-full">
-            <%= f.label :prompt, "Prompt", class: "label" %>
-            <div class="mt-2">
-              <%= f.text_area :prompt,
-                  value: @config["prompt"],
-                  rows: 4,
-                  class: "textarea textarea-bordered w-full" %>
-            </div>
-          </div>
-          <div class="card-actions justify-end mt-6">
-            <%= f.submit "Save Changes",
-                class: "btn btn-primary" %>
-          </div>
         <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/python_components/README.md
+++ b/python_components/README.md
@@ -4,6 +4,8 @@ The components in this directory cover various document handling processes. They
 
 For local development, Lambda compatible components should be setup automatically by running `docker compose up` in the project root. Lambda functions should return JSON responses with `statusCode` and `body` keys.
 
+To set API keys for AI services, visit the application configuration page. API keys are saved to the localstack version of AWS Secretes Manager.
+
 ## Codestyle
 
 The Python components should be PEP8 compliant. They are currently linted with isort, black and flake8 with discrete budgets via Github Actions. To reproduce the CI output directly, from the python_components directory build the CI image locally `docker build -t asap_pdf:ci .` and run `docker run --rm -v ./:/workspace asap_pdf:ci scripts/ci_run_linting.sh "**/*.py"`.

--- a/python_components/recommendation/Dockerfile
+++ b/python_components/recommendation/Dockerfile
@@ -3,6 +3,7 @@ FROM public.ecr.aws/lambda/python:3.12
 # Copy requirements.txt & config.json
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 COPY 2025-03-11-56-llm-gemini.patch ${LAMBDA_TASK_ROOT}
+COPY models.json ${LAMBDA_TASK_ROOT}
 
 # Install the specified packages
 RUN dnf install poppler-utils git-all -y &&\
@@ -13,9 +14,6 @@ RUN dnf install poppler-utils git-all -y &&\
     git apply 2025-03-11-56-llm-gemini.patch &&\
     llm install -e '.[test]' &&\
     mkdir ${LAMBDA_TASK_ROOT}/data
-
-# Copy application config
-COPY config.json ${LAMBDA_TASK_ROOT}
 
 # Copy function code
 COPY lambda_function.py ${LAMBDA_TASK_ROOT}

--- a/python_components/recommendation/lambda_function.py
+++ b/python_components/recommendation/lambda_function.py
@@ -238,7 +238,6 @@ def handler(event, context):
                     "why_individualized": 'Document was encrypted and should be manually evaluated for the "Individualized Content" exception.',
                 }
             logging.info("Writing LLM results to Rails API...")
-            # TODO figure out how to contextualize this.
             post_document(event["asap_endpoint"], document_id, response_json)
 
         return {

--- a/python_components/recommendation/lambda_function.py
+++ b/python_components/recommendation/lambda_function.py
@@ -62,7 +62,7 @@ def pdf_to_attachments(pdf_path: str, output_path: str, page_limit: int) -> list
 
 
 def validate_event(event):
-    for required_key in ("model_name", "documents", "page_limit"):
+    for required_key in ("model_name", "documents", "page_limit", "asap_endpoint"):
         if required_key not in event:
             raise ValueError(
                 f"Function called without required parameter, {required_key}."
@@ -239,8 +239,7 @@ def handler(event, context):
                 }
             logging.info("Writing LLM results to Rails API...")
             # TODO figure out how to contextualize this.
-            url = "http://host.docker.internal:3000/api/documents/inference"
-            post_document(url, document_id, response_json)
+            post_document(event["asap_endpoint"], document_id, response_json)
 
         return {
             "statusCode": 200,

--- a/python_components/recommendation/lambda_function.py
+++ b/python_components/recommendation/lambda_function.py
@@ -19,24 +19,9 @@ ch.setLevel(logging.DEBUG)
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-
-def get_config():
-    with open("config.json", "r") as f:
-        return json.load(f)
-
-
 def get_models():
     with open("models.json", "r") as f:
         return json.load(f)
-
-
-def get_supported_models(local_mode):
-    if local_mode:
-        config = get_config()
-        return {config["active_model"]: {"key": config["key"]}}
-    else:
-        return get_models()
-
 
 def get_secret(secret_name: str, local_mode: bool) -> str:
     if local_mode:
@@ -203,31 +188,19 @@ def handler(event, context):
         logger.info("Validating payload...")
         validate_event(event)
         local_mode = os.environ.get("ASAP_LOCAL_MODE", False)
-        supported_models = get_supported_models(local_mode)
+        supported_models = get_models()
         if event["model_name"] not in supported_models.keys():
             supported_model_list = ",".join(supported_models.keys())
             raise ValueError(
                 f"Unsupported model: {event["model_name"]}. Options are: {supported_model_list}"
             )
-
-        if local_mode:
-            api_key = supported_models[event["model_name"]]["key"]
-            config = get_config()
-            page_limit = (
-                config["page_limit"]
-                if event["page_limit"] == 0
-                else event["page_limit"]
-            )
-        else:
-            api_key = get_secret(
-                supported_models[event["model_name"]]["key"], local_mode
-            )
-            page_limit = (
-                "unlimited" if event["page_limit"] == 0 else event["page_limit"]
-            )
-
+        api_key = get_secret(
+            supported_models[event["model_name"]]["key"], local_mode
+        )
+        page_limit = (
+            "unlimited" if event["page_limit"] == 0 else event["page_limit"]
+        )
         logger.info(f"Page limit set to {page_limit}.")
-
         model = llm.get_model(event["model_name"])
         model.key = api_key
         # Send images off to our friend.

--- a/python_components/recommendation/models.json
+++ b/python_components/recommendation/models.json
@@ -2,7 +2,7 @@
   "anthropic/claude-3-5-haiku-latest": {
     "key": "asap-pdf/production/ANTHROPIC_KEY"
   },
-  "gemini-1.5-pro-latest": {
+  "gemini-2.0-pro-exp-02-05": {
     "key": "asap-pdf/production/GOOGLE_AI_KEY"
   }
 }

--- a/python_components/summary/Dockerfile
+++ b/python_components/summary/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/lambda/python:3.12
 
 # Copy requirements.txt & config.json
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
-COPY config.json ${LAMBDA_TASK_ROOT}
+COPY models.json ${LAMBDA_TASK_ROOT}
 
 # Install the specified packages
 RUN dnf install poppler-utils -y &&\

--- a/python_components/summary/config.json.example
+++ b/python_components/summary/config.json.example
@@ -1,6 +1,0 @@
-{
-  "active_model": "gemini-1.5-pro-latest",
-  "key": "YOUR_SECRET_KEY",
-  "page_limit": 7,
-  "prompt": "The following images show a local government document. Could you summarize the contents in two or three sentences?"
-}


### PR DESCRIPTION
Some of our local lambda setup made assumptions that would not work in production. This PR makes adjustments to keep the best parity we can with the production environment, locally and to prevent copying API keys into our docker images.

We now store API keys in the localstack secret manager for development and testing environments. We no longer write the config.json file into the Docker image. Within the container the API keys are always pulled from secret manager.