### PR TITLE
Collect number of tables and number of images found in PDF

### DIFF
--- a/python_components/crawler/Dockerfile
+++ b/python_components/crawler/Dockerfile
@@ -2,5 +2,4 @@ FROM python:latest
 COPY requirements.txt .
 ENV PYTHONPATH=\/workspace
 RUN pip install -r requirements.txt --trusted-host pypi.python.org --no-cache-dir
-RUN apt-get update && apt-get install -y --no-install-recommends default-jre
 WORKDIR /workspace

--- a/python_components/crawler/Dockerfile
+++ b/python_components/crawler/Dockerfile
@@ -2,4 +2,5 @@ FROM python:latest
 COPY requirements.txt .
 ENV PYTHONPATH=\/workspace
 RUN pip install -r requirements.txt --trusted-host pypi.python.org --no-cache-dir
+RUN apt-get update && apt-get install -y --no-install-recommends default-jre
 WORKDIR /workspace

--- a/python_components/crawler/requirements.txt
+++ b/python_components/crawler/requirements.txt
@@ -3,12 +3,15 @@ beautifulsoup4==4.13.3
 importlib-metadata==8.0.0
 inflect==7.3.1
 jaraco.collections==5.1.0
+jpype1==1.5.2
 lxml==5.3.1
 packaging==24.2
 pandas==2.2.3
+pillow==11.1.0
 pip-chill==1.0.3
 platformdirs==4.2.2
 pypdf==5.3.1
+tabula-py==2.10.0
 tldextract==5.1.3
 tomli==2.0.1
 tqdm==4.67.1

--- a/python_components/crawler/requirements.txt
+++ b/python_components/crawler/requirements.txt
@@ -3,15 +3,12 @@ beautifulsoup4==4.13.3
 importlib-metadata==8.0.0
 inflect==7.3.1
 jaraco.collections==5.1.0
-jpype1==1.5.2
 lxml==5.3.1
 packaging==24.2
 pandas==2.2.3
-pillow==11.1.0
 pip-chill==1.0.3
 platformdirs==4.2.2
-pypdf==5.3.1
-tabula-py==2.10.0
+PyMuPDF==1.25.5
 tldextract==5.1.3
 tomli==2.0.1
 tqdm==4.67.1


### PR DESCRIPTION
Addresses [ASAP-83](https://codeforamerica.atlassian.net/browse/ASAP-83?atlOrigin=eyJpIjoiOGRmZWNjY2Y4NzRhNGE5Yzg5MWViNzJlYzFiOTczYzIiLCJwIjoiaiJ9) by collecting the number of images and tables embedded within the PDF. 

In order to test this, please pull down this branch, build (`docker build -t asap_pdf:crawler .`) and run its docker container (`docker run --rm -it -v "$(pwd):/workspace" asap_pdf:crawler bash`), and then run the `crawler.py` script. I'd recommend either editing the crawl depth for a site within the `config.json` file (e.g., change SLC's to two and run on their site) or run over a smaller site (e.g., ours!) by adding this to the file:

```{json}
"https://codeforamerica.org/": {
        "allow_list": ["https://codeforamerica.org/"],
        "use_sitemap": false,
        "depth": 2
  }
```

Running the script over Code for America's site should take less than five minutes.

[ASAP-83]: https://codeforamerica.atlassian.net/browse/ASAP-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ