### PR TITLE
1337 sprint 5 bugfixes

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -24,7 +24,7 @@ class DocumentsController < AuthenticatedController
   end
 
   def update_document_category
-    value = params[:value].presence || Document::DEFAULT_DOCUMENT_CATEGORY
+    value = params[:value].presence
     if @document.update(document_category: value)
       render json: {
         display_text: value
@@ -62,7 +62,7 @@ class DocumentsController < AuthenticatedController
 
     # Set Unknown as default for empty values
     existing_recommendation = @document.accessibility_recommendation || Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION
-    existing_category = @document.document_category || Document::DEFAULT_DOCUMENT_CATEGORY
+    existing_category = @document.document_category
 
     if @document.update(
       status: params[:status],

--- a/app/javascript/controllers/dropdown_edit_controller.js
+++ b/app/javascript/controllers/dropdown_edit_controller.js
@@ -81,7 +81,7 @@ export default class extends Controller {
         // Preserve the magic wand icon when updating display text
         const icon = this.displayTarget.querySelector('i')
         this.displayTarget.innerHTML = ''
-        if (icon) {
+        if (icon && !icon.classList.contains('leave-icon')) {
           icon.remove()
         }
         this.displayTarget.appendChild(document.createTextNode(' ' + data.display_text))

--- a/app/javascript/controllers/dropdown_edit_controller.js
+++ b/app/javascript/controllers/dropdown_edit_controller.js
@@ -82,10 +82,7 @@ export default class extends Controller {
         const icon = this.displayTarget.querySelector('i')
         this.displayTarget.innerHTML = ''
         if (icon) {
-          const span = document.createElement('span')
-          span.className = 'text-xs font-normal'
-          span.appendChild(icon)
-          this.displayTarget.appendChild(span)
+          icon.remove()
         }
         this.displayTarget.appendChild(document.createTextNode(' ' + data.display_text))
         this.hideSelect()

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -46,7 +46,7 @@ export default class extends Controller {
   }
 
   updateButtonStyles(activeButton) {
-    [this.summaryButtonTarget, this.metadataButtonTarget, this.historyButtonTarget].forEach(button => {
+    [this.summaryButtonTarget, this.metadataButtonTarget, this.recommendationButtonTarget, this.historyButtonTarget].forEach(button => {
       button.classList.remove("tab-active")
     })
     activeButton.classList.add("tab-active")

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -45,13 +45,9 @@ class Document < ApplicationRecord
     scope
   }
 
-  DEFAULT_DOCUMENT_CATEGORY, DEFAULT_ACCESSIBILITY_RECOMMENDATION = %w[Other Needs\ Decision].freeze
+  DEFAULT_ACCESSIBILITY_RECOMMENDATION = "Needs Decision".freeze
 
-  CONTENT_TYPES = [
-    DEFAULT_DOCUMENT_CATEGORY, "Agreement", "Agenda", "Brochure", "Diagram", "Flyer", "Form", "Form Instructions",
-    "Job", "Letter", "Map", "Memo", "Policy", "Slides",
-    "Press", "Procurement", "Notice", "Report", "Spreadsheet", "Unknown"
-  ].freeze
+  CONTENT_TYPES = %w[Agreement Agenda Brochure Diagram Flyer Form Job Letter Policy Slides Press Procurement Notice Report Spreadsheet].freeze
 
   LEAVE_ACCESSIBILITY_RECOMMENDATION, REMEDIATE_ACCESSIBILITY_RECOMMENDATION = %w[Leave Remediate].freeze
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -76,23 +76,16 @@ class Document < ApplicationRecord
     last_change.present? && last_change.whodunnit.present?
   end
 
-  def accessibility_recommendation
-    # Check if there was a change and if the user was non-nil
-    return self[:accessibility_recommendation] if last_changed_by_human? "accessibility_recommendation"
-    accessibility_recommendation_from_inferences
-  end
-
   def accessibility_recommendation_from_inferences
     # Otherwise calculate based on inferences
     if document_inferences.any?
       exceptions = self.exceptions
       if exceptions.any?
-        return LEAVE_ACCESSIBILITY_RECOMMENDATION
+        LEAVE_ACCESSIBILITY_RECOMMENDATION
       else
-        return REMEDIATE_ACCESSIBILITY_RECOMMENDATION
+        REMEDIATE_ACCESSIBILITY_RECOMMENDATION
       end
     end
-    DEFAULT_ACCESSIBILITY_RECOMMENDATION
   end
 
   def exceptions(include_value_check = true)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -71,8 +71,8 @@ class Document < ApplicationRecord
   end
 
   def last_changed_by_human?(field)
-    versions.where("object_changes LIKE ?", "%#{field}%")
-    last_change = versions.order(created_at: :desc).first
+    field_versions = versions.where("object_changes LIKE ?", "%#{field}%")
+    last_change = field_versions.order(created_at: :desc).first
     last_change.present? && last_change.whodunnit.present?
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -146,8 +146,8 @@ class Site < ApplicationRecord
 
   def attributes_from(data)
     {
-      document_category: (data[:predicted_category] || data[:document_category]),
-      document_category_confidence: (data[:predicted_category_confidence] || data[:document_category_confidence]),
+      document_category: data[:predicted_category] || data[:document_category],
+      document_category_confidence: data[:predicted_category_confidence] || data[:document_category_confidence],
       url: data[:url],
       modification_date: data[:modification_date],
       file_size: data[:file_size],

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -146,8 +146,8 @@ class Site < ApplicationRecord
 
   def attributes_from(data)
     {
-      document_category: data[:predicted_category],
-      document_category_confidence: data[:predicted_category_confidence],
+      document_category: (data[:predicted_category] || data[:document_category]),
+      document_category_confidence: (data[:predicted_category_confidence] || data[:document_category_confidence]),
       url: data[:url],
       modification_date: data[:modification_date],
       file_size: data[:file_size],

--- a/app/views/documents/_recommendation_list.html.erb
+++ b/app/views/documents/_recommendation_list.html.erb
@@ -6,7 +6,7 @@
       <dt class="text-sm/6 font-bold text-gray-900 text-left">AI Accessibility Suggestion</dt>
       <% rec_from_inferences = document.accessibility_recommendation_from_inferences %>
       <% rec_from_db = document.accessibility_recommendation %>
-      <% if rec_from_inferences == rec_from_db %>
+      <% if rec_from_inferences.present? && (rec_from_db == Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION || rec_from_inferences == rec_from_db) %>
         <dd class="mt-1 text-sm/6 text-gray-700 sm:col-span-2 sm:mt-0 text-left"><%= document.accessibility_recommendation_from_inferences %></dd>
       <% else %>
         <dd class="mt-1 text-sm/6 text-gray-700 sm:col-span-2 sm:mt-0 text-left"><%= rec_from_inferences %> (User

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -127,7 +127,7 @@
                       <div class="hover:underline">
                         <%= document.document_category %>
                       </div>
-                      <% if document.document_category.present? && document.document_category_confidence.present? %>
+                      <% if document.document_category.present? && document.document_category_confidence.present? && !document.last_changed_by_human?("document_category") %>
                         <div class="text-xs text-gray-500 flex items-center gap-1">
                           <i class="fas fa-wand-magic-sparkles"></i>
                           <%= number_to_percentage(document.document_category_confidence * 100, precision: 0) %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -141,13 +141,13 @@
                       </select>
                     </td>
                     <td class="px-3 py-4 text-sm text-gray-500 w-32" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="accessibility_recommendation">
-                      <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer hover:underline">
-                        <%= document.accessibility_recommendation.present? ? document.accessibility_recommendation : Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s %>
-                        <% rec_from_inferences = document.accessibility_recommendation_from_inferences %>
+                      <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer text-primary flex flex-col gap-1">
                         <% rec_from_db = document.accessibility_recommendation %>
-                        <% if rec_from_db != Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s && rec_from_db == rec_from_inferences %>
-                          <br>
-                          (AI suggestion)
+                        <%= rec_from_db.present? ? rec_from_db : Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s %>
+                        <% if rec_from_db != Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s && !document.last_changed_by_human?("accessibility_recommendation") %>
+                          <div class="text-xs text-gray-500 flex items-center gap-1">
+                            <i class="fas fa-wand-magic-sparkles"></i>AI suggestion
+                          </div>
                         <% end %>
                       </div>
                       <select data-dropdown-edit-target="select" data-action="change->dropdown-edit#updateValue blur->dropdown-edit#hideSelect" class="hidden w-[125%] bg-white border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 p-2">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -42,157 +42,150 @@
         <div class="bg-white shadow-sm rounded-b-lg overflow-visible">
           <table class="min-w-full divide-y divide-gray-200 table-zebra">
             <thead class="bg-gray-50">
-              <tr>
-                <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-12">PDF</th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[40%]">
-                  <%= link_to site_documents_path(@site, sort: 'file_name', direction: (params[:sort] == 'file_name' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
-                    File Name
-                    <% if params[:sort] == 'file_name' %>
-                      <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
-                    <% else %>
-                      <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
-                    <% end %>
+            <tr>
+              <th scope="col" class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-12">PDF</th>
+              <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[40%]">
+                <%= link_to site_documents_path(@site, sort: 'file_name', direction: (params[:sort] == 'file_name' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
+                  File Name
+                  <% if params[:sort] == 'file_name' %>
+                    <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
+                  <% else %>
+                    <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
                   <% end %>
-                </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  <%= link_to site_documents_path(@site, sort: 'modification_date', direction: (params[:sort] == 'modification_date' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
-                    Last Modified
-                    <% if params[:sort] == 'modification_date' %>
-                      <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
-                    <% else %>
-                      <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
-                    <% end %>
+                <% end %>
+              </th>
+              <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                <%= link_to site_documents_path(@site, sort: 'modification_date', direction: (params[:sort] == 'modification_date' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
+                  Last Modified
+                  <% if params[:sort] == 'modification_date' %>
+                    <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
+                  <% else %>
+                    <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
                   <% end %>
-                </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32">
-                  <%= link_to site_documents_path(@site, sort: 'document_category', direction: (params[:sort] == 'document_category' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
-                    Type
-                    <% if params[:sort] == 'document_category' %>
-                      <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
-                    <% else %>
-                      <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
-                    <% end %>
+                <% end %>
+              </th>
+              <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32">
+                <%= link_to site_documents_path(@site, sort: 'document_category', direction: (params[:sort] == 'document_category' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
+                  Type
+                  <% if params[:sort] == 'document_category' %>
+                    <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
+                  <% else %>
+                    <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
                   <% end %>
-                </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32">
-                  <%= link_to site_documents_path(@site, sort: 'accessibility_recommendation', direction: (params[:sort] == 'accessibility_recommendation' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
-                    Decision
-                    <% if params[:sort] == 'accessibility_recommendation' %>
-                      <i class="fas fa-<%= params[:direction] == 'desc' ? 'sort-down' : 'sort-up' %> ml-1 text-primary-500"></i>
-                    <% else %>
-                      <i class="fas fa-sort ml-1 text-gray-400 group-hover:text-gray-500"></i>
-                    <% end %>
-                  <% end %>
-                </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notes</th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Move</th>
-              </tr>
+                <% end %>
+              </th>
+              <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Decision</th>
+              <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notes</th>
+              <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Move</th>
+            </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
-              <% if @documents.empty? %>
-                <tr>
-                  <td colspan="7" class="px-3 py-8">
-                    <div class="flex items-center justify-center text-gray-500">
-                      <i class="fas fa-folder-open mr-2"></i>
-                      <span>No documents found</span>
+            <% if @documents.empty? %>
+              <tr>
+                <td colspan="7" class="px-3 py-8">
+                  <div class="flex items-center justify-center text-gray-500">
+                    <i class="fas fa-folder-open mr-2"></i>
+                    <span>No documents found</span>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+            <% @documents.each do |document| %>
+              <tr>
+                <td class="px-4 py-4 whitespace-nowrap text-lg text-gray-500 text-center w-12">
+                  <button onclick="pdf_modal_<%= document.id %>.showModal()" class="text-primary-600 hover:text-primary-900" title="Click to view <%= document.file_name %>">
+                    <i class="fas fa-file-pdf"></i>
+                  </button>
+                  <%= render partial: "documents/pdf_modal", locals: { document: document } %>
+                </td>
+                <td class="px-3 py-4 text-sm w-[40%]" title="<%= document.file_name %>">
+                  <div class="flex flex-col gap-1">
+                    <div class="text-gray-900">
+                      <button onclick="pdf_modal_<%= document.id %>.showModal()"><%= document.file_name&.truncate(80) %></button>
                     </div>
-                  </td>
-                </tr>
-              <% end %>
-              <% @documents.each do |document| %>
-                <tr>
-                  <td class="px-4 py-4 whitespace-nowrap text-lg text-gray-500 text-center w-12">
-                    <button onclick="pdf_modal_<%= document.id %>.showModal()" class="text-primary-600 hover:text-primary-900" title="Click to view <%= document.file_name %>">
-                      <i class="fas fa-file-pdf"></i>
-                    </button>
-                    <%= render partial: "documents/pdf_modal", locals: { document: document } %>
-                  </td>
-                  <td class="px-3 py-4 text-sm w-[40%]" title="<%= document.file_name %>">
-                    <div class="flex flex-col gap-1">
-                      <div class="text-gray-900"><button onclick="pdf_modal_<%= document.id %>.showModal()"><%= document.file_name&.truncate(80) %></button></div>
-                      <% source = document_source(document.primary_source) %>
-                      <div class="text-gray-400 flex items-center">
-                        <%= source[:text] %>
-                        <% if source[:url].present? %>
-                          <a href="<%= source[:url] %>" target="_blank" rel="noopener noreferrer" class="ml-1 text-primary-600 hover:text-primary-900" title="Open source in new tab">
-                            <i class="fas fa-external-link-alt text-sm"></i>
-                          </a>
-                        <% end %>
-                      </div>
-                    </div>
-                  </td>
-                  <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500"><%= document.modification_date&.strftime("%b %d, %Y") %></td>
-                  <td class="px-3 py-4 text-sm w-32" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="document_category">
-                    <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer <%= document.document_category.present? ? 'text-primary' : 'text-gray-500' %> flex flex-col gap-1">
-                      <div class="hover:underline">
-                        <%= document.document_category %>
-                      </div>
-                      <% if document.document_category.present? && document.document_category_confidence.present? && !document.last_changed_by_human?("document_category") %>
-                        <div class="text-xs text-gray-500 flex items-center gap-1">
-                          <i class="fas fa-wand-magic-sparkles"></i>
-                          <%= number_to_percentage(document.document_category_confidence * 100, precision: 0) %>
-                        </div>
+                    <% source = document_source(document.primary_source) %>
+                    <div class="text-gray-400 flex items-center">
+                      <%= source[:text] %>
+                      <% if source[:url].present? %>
+                        <a href="<%= source[:url] %>" target="_blank" rel="noopener noreferrer" class="ml-1 text-primary-600 hover:text-primary-900" title="Open source in new tab">
+                          <i class="fas fa-external-link-alt text-sm"></i>
+                        </a>
                       <% end %>
                     </div>
-                    <select data-dropdown-edit-target="select" data-action="change->dropdown-edit#updateValue blur->dropdown-edit#hideSelect" class="hidden w-[125%] bg-white border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 p-2">
-                      <% Document::CONTENT_TYPES.each do |key| %>
-                        <option value="<%= key %>" <%= document.document_category == key ? 'selected' : '' %>><%= key %></option>
-                        <% end %>
-                      </select>
-                    </td>
-                    <td class="px-3 py-4 text-sm text-gray-500 w-32" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="accessibility_recommendation">
-                      <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer text-primary flex flex-col gap-1">
-                        <% rec_from_db = document.accessibility_recommendation %>
-                        <%= rec_from_db.present? ? rec_from_db : Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s %>
-                        <% if rec_from_db != Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s && !document.last_changed_by_human?("accessibility_recommendation") %>
-                          <div class="text-xs text-gray-500 flex items-center gap-1">
-                            <i class="fas fa-wand-magic-sparkles"></i>AI suggestion
-                          </div>
-                        <% end %>
-                      </div>
-                      <select data-dropdown-edit-target="select" data-action="change->dropdown-edit#updateValue blur->dropdown-edit#hideSelect" class="hidden w-[125%] bg-white border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 p-2">
-                        <% Document::DECISION_TYPES.each do |key, label| %>
-                          <option value="<%= key %>" <%= document.accessibility_recommendation == key ? 'selected' : '' %>><%= label %></option>
-                          <% end %>
-                        </select>
-                      </td>
-                      <td class="px-3 py-4 text-sm text-gray-500" data-controller="text-edit" data-text-edit-document-id-value="<%= document.id %>" data-text-edit-field-value="notes">
-                        <div data-text-edit-target="display" data-action="click->text-edit#showTextarea" class="cursor-pointer hover:underline min-w-40">
-                          <%= document.notes.present? ? document.notes : "No notes" %>
-                        </div>
-                        <textarea
-                      data-text-edit-target="textarea"
-                      data-action="blur->text-edit#updateValue keydown->text-edit#updateValue input->text-edit#adjustHeight"
-                      class="hidden w-[125%] min-h-[6em] p-2 border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500"
-                    ><%= document.notes %></textarea>
-                      </td>
-                      <td class="px-3 py-4 text-sm text-gray-500 relative text-center h-[60px]" data-controller="status" data-document-id="<%= document.id %>">
-                        <button class="text-gray-500 hover:text-gray-700 z-[50]" data-action="status#toggleMenu">
-                          <i class="fas fa-ellipsis-v"></i>
-                        </button>
-                        <div data-status-target="menu" class="hidden absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-[100]">
-                          <div class="py-1" role="menu">
-                            <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem" data-action="status#updateStatus" data-status="">
-                              Backlog
-                            </a>
-                            <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem" data-action="status#updateStatus" data-status="in_review">
-                              In Review
-                            </a>
-                            <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem" data-action="status#updateStatus" data-status="done">
-                              Done
-                            </a>
-                          </div>
-                        </div>
-                      </td>
-                    </tr>
+                  </div>
+                </td>
+                <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500"><%= document.modification_date&.strftime("%b %d, %Y") %></td>
+                <td class="px-3 py-4 text-sm w-32" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="document_category">
+                  <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer <%= document.document_category.present? ? 'text-primary' : 'text-gray-500' %> flex flex-col gap-1">
+                    <div class="hover:underline">
+                      <%= document.document_category %>
+                    </div>
+                  </div>
+                  <select data-dropdown-edit-target="select" data-action="change->dropdown-edit#updateValue blur->dropdown-edit#hideSelect" class="hidden w-[125%] bg-white border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 p-2">
+                    <% Document::CONTENT_TYPES.each do |key| %>
+                      <option value="<%= key %>" <%= document.document_category == key ? 'selected' : '' %>><%= key %></option>
+                    <% end %>
+                  </select>
+                  <% if document.document_category.present? && document.document_category_confidence.present? && !document.last_changed_by_human?("document_category") %>
+                    <div class="text-xs text-gray-500 flex items-center gap-1">
+                      <i class="fas fa-wand-magic-sparkles"></i>
+                      <%= number_to_percentage(document.document_category_confidence * 100, precision: 0) %>
+                    </div>
                   <% end %>
-                </tbody>
-              </table>
-              <div class="px-6 py-4 <%= "border-t" if @total_documents > 25 %>">
-                <%= paginate @documents %>
-              </div>
-            </div>
+                </td>
+                <td class="px-3 py-4 text-sm text-gray-500 w-32" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="accessibility_recommendation">
+                  <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer text-primary flex flex-col gap-1">
+                    <%= document.accessibility_recommendation.present? ? document.accessibility_recommendation : Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s %>
+                  </div>
+                  <select data-dropdown-edit-target="select" data-action="change->dropdown-edit#updateValue blur->dropdown-edit#hideSelect" class="hidden w-[125%] bg-white border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500 p-2">
+                    <% Document::DECISION_TYPES.each do |key, label| %>
+                      <option value="<%= key %>" <%= document.accessibility_recommendation == key ? 'selected' : '' %>><%= label %></option>
+                    <% end %>
+                  </select>
+                  <% rec_from_inferences = document.accessibility_recommendation_from_inferences %>
+                  <% if rec_from_inferences.present? %>
+                    <div class="text-xs text-gray-500 flex items-center gap-1">
+                      <i class="fas fa-wand-magic-sparkles leave-icon"></i><%= rec_from_inferences %>
+                    </div>
+                  <% end %>
+                </td>
+                <td class="px-3 py-4 text-sm text-gray-500" data-controller="text-edit" data-text-edit-document-id-value="<%= document.id %>" data-text-edit-field-value="notes">
+                  <div data-text-edit-target="display" data-action="click->text-edit#showTextarea" class="cursor-pointer hover:underline min-w-40">
+                    <%= document.notes.present? ? document.notes : "No notes" %>
+                  </div>
+                  <textarea
+                    data-text-edit-target="textarea"
+                    data-action="blur->text-edit#updateValue keydown->text-edit#updateValue input->text-edit#adjustHeight"
+                    class="hidden w-[125%] min-h-[6em] p-2 border border-gray-300 rounded-md shadow-sm focus:border-primary-500 focus:ring-primary-500"
+                  ><%= document.notes %></textarea>
+                </td>
+                <td class="px-3 py-4 text-sm text-gray-500 relative text-center h-[60px]" data-controller="status" data-document-id="<%= document.id %>">
+                  <button class="text-gray-500 hover:text-gray-700 z-[50]" data-action="status#toggleMenu">
+                    <i class="fas fa-ellipsis-v"></i>
+                  </button>
+                  <div data-status-target="menu" class="hidden absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-[100]">
+                    <div class="py-1" role="menu">
+                      <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem" data-action="status#updateStatus" data-status="">
+                        Backlog
+                      </a>
+                      <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem" data-action="status#updateStatus" data-status="in_review">
+                        In Review
+                      </a>
+                      <a href="#" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem" data-action="status#updateStatus" data-status="done">
+                        Done
+                      </a>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+          <div class="px-6 py-4 <%= "border-t" if @total_documents > 25 %>">
+            <%= paginate @documents %>
           </div>
         </div>
       </div>
     </div>
+  </div>
+</div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -123,11 +123,11 @@
                   </td>
                   <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500"><%= document.modification_date&.strftime("%b %d, %Y") %></td>
                   <td class="px-3 py-4 text-sm w-32" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="document_category">
-                    <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer <%= document.document_category.present? && document.document_category != Document::DEFAULT_DOCUMENT_CATEGORY ? 'text-primary' : 'text-gray-500' %> flex flex-col gap-1">
+                    <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer <%= document.document_category.present? ? 'text-primary' : 'text-gray-500' %> flex flex-col gap-1">
                       <div class="hover:underline">
-                        <%= document.document_category.present? ? document.document_category : Document::DEFAULT_DOCUMENT_CATEGORY %>
+                        <%= document.document_category %>
                       </div>
-                      <% if document.document_category.present? && document.document_category != Document::DEFAULT_DOCUMENT_CATEGORY && document.document_category_confidence.present? %>
+                      <% if document.document_category.present? && document.document_category_confidence.present? %>
                         <div class="text-xs text-gray-500 flex items-center gap-1">
                           <i class="fas fa-wand-magic-sparkles"></i>
                           <%= number_to_percentage(document.document_category_confidence * 100, precision: 0) %>

--- a/db/migrate/20250203181826_create_documents.rb
+++ b/db/migrate/20250203181826_create_documents.rb
@@ -7,7 +7,7 @@ class CreateDocuments < ActiveRecord::Migration[8.0]
       t.text :source
       t.string :status
       t.string :document_status, default: "discovered"
-      t.string :document_category, default: Document::DEFAULT_DOCUMENT_CATEGORY
+      t.string :document_category, default: "Unknown"
       t.float :document_category_confidence
       t.text :accessibility_recommendation, default: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION
       t.float :accessibility_confidence

--- a/db/migrate/20250411210519_remove_category_default_value.rb
+++ b/db/migrate/20250411210519_remove_category_default_value.rb
@@ -1,0 +1,6 @@
+class RemoveCategoryDefaultValue < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default(:documents, :document_category, nil)
+    change_column_null :documents, :document_category, false
+  end
+end

--- a/db/migrate/20250411210519_remove_category_default_value.rb
+++ b/db/migrate/20250411210519_remove_category_default_value.rb
@@ -2,5 +2,6 @@ class RemoveCategoryDefaultValue < ActiveRecord::Migration[8.0]
   def change
     change_column_default(:documents, :document_category, nil)
     change_column_null :documents, :document_category, false
+    change_column_default(:documents, :accessibility_recommendation, Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION)
   end
 end

--- a/spec/features/document_spec.rb
+++ b/spec/features/document_spec.rb
@@ -180,7 +180,7 @@ describe "documents function as expected", js: true, type: :feature do
     within("#document-list .modal") do
       click_button "History"
       expect(page).to have_content("Notes: blank → Fee fi fo fum")
-      expect(page).to have_content("Document category: Other → Agenda")
+      expect(page).to have_content("Document category: blank → Agenda")
       # Check for the summary we updated above.
       click_button "Summary"
       expect(page).to have_content("A lovely example of accessible PDF practices.")

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Document, type: :model do
   it { should belong_to(:site) }
 
   describe "#file_name" do
-    let(:document) { Document.new }
+    let(:document) { Document.new(document_category: "Brochure") }
     it { should validate_presence_of(:file_name) }
     it "handles file names with special characters" do
       document.file_name = "%C3%81fidos_GrowGreen_web.pdf"
@@ -13,7 +13,7 @@ RSpec.describe Document, type: :model do
   end
 
   describe "#url" do
-    let(:document) { Document.new }
+    let(:document) { Document.new(document_category: "Brochure") }
     it { should validate_presence_of(:url) }
     it { should allow_value("http://example.com").for(:url) }
     it { should_not allow_value("invalid-url").for(:url) }
@@ -33,7 +33,7 @@ RSpec.describe Document, type: :model do
   end
 
   describe "#primary_source" do
-    let(:document) { Document.new }
+    let(:document) { Document.new(document_category: "Brochure") }
 
     it "returns nil when source is nil" do
       document.source = nil
@@ -53,7 +53,7 @@ RSpec.describe Document, type: :model do
 
   describe "S3 storage" do
     let(:site) { create(:site, primary_url: "https://www.city.org") }
-    let(:document) { create(:document, site: site) }
+    let(:document) { Document.new(document_category: "Brochure", site: site) }
 
     describe "#s3_path" do
       it "generates correct path using site prefix and document id" do

--- a/spec/requests/api/sites_spec.rb
+++ b/spec/requests/api/sites_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe AsapPdf::API do
     let(:valid_documents) do
       [
         {url: "https://example.com/doc1.pdf", modification_date: timestamp, document_category: "Brochure"},
-        {url: "https://example.com/doc2.pdf", modification_date: timestamp, document_category: "Brochure"},
+        {url: "https://example.com/doc2.pdf", modification_date: timestamp, document_category: "Brochure"}
       ]
     end
 

--- a/spec/requests/api/sites_spec.rb
+++ b/spec/requests/api/sites_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe AsapPdf::API do
     let(:timestamp) { Time.current }
     let(:valid_documents) do
       [
-        {url: "https://example.com/doc1.pdf", modification_date: timestamp},
-        {url: "https://example.com/doc2.pdf", modification_date: timestamp}
+        {url: "https://example.com/doc1.pdf", modification_date: timestamp, document_category: "Brochure"},
+        {url: "https://example.com/doc2.pdf", modification_date: timestamp, document_category: "Brochure"},
       ]
     end
 
@@ -92,7 +92,8 @@ RSpec.describe AsapPdf::API do
           url: valid_documents.first[:url],
           modification_date: 1.day.ago,
           file_name: "doc1.pdf",
-          document_status: "discovered"
+          document_status: "discovered",
+          document_category: "Brochure"
         )
 
         expect {
@@ -111,7 +112,8 @@ RSpec.describe AsapPdf::API do
           url: valid_documents.first[:url],
           modification_date: timestamp,
           file_name: "doc1.pdf",
-          document_status: "discovered"
+          document_status: "discovered",
+          document_category: "Brochure"
         )
 
         expect {


### PR DESCRIPTION
* Removes "Other" document category, reconciles app document category list with python component. Makes document category a required field. [ASAP-123](https://codeforamerica.atlassian.net/browse/ASAP-123)
* Fix lingering active state of suggestions tab. [ASAP-134](https://codeforamerica.atlassian.net/browse/ASAP-134)
* Always show AI exception suggestion beneath human one. Add a magic wand icon. [ASAP-121](https://codeforamerica.atlassian.net/browse/ASAP-121)

[ASAP-123]: https://codeforamerica.atlassian.net/browse/ASAP-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASAP-134]: https://codeforamerica.atlassian.net/browse/ASAP-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASAP-121]: https://codeforamerica.atlassian.net/browse/ASAP-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ