### PR TITLE
Add support for multi-user sites

### DIFF
--- a/app/controllers/concerns/access.rb
+++ b/app/controllers/concerns/access.rb
@@ -1,11 +1,17 @@
 module Access
+  def ensure_user_admin
+    unless Current.user.is_admin?
+      redirect_to sites_path, alert: "You don't have permission to access that page."
+    end
+  end
+
   def ensure_user_site_access
     if !Current.user.is_admin? && (Current.user.site.nil? || Current.user.site.id != @site.id)
       redirect_to sites_path, alert: "You don't have permission to access that site."
     end
   end
 
-  def ensure_document_access
+  def ensure_user_document_access
     if !Current.user.is_admin? && (Current.user.site.nil? || Current.user.site.documents.find(@document.id).nil?)
       redirect_to sites_path, alert: "You don't have permission to perform that action on document."
     end

--- a/app/controllers/concerns/access.rb
+++ b/app/controllers/concerns/access.rb
@@ -1,0 +1,13 @@
+module Access
+  def ensure_user_site_access
+    if !Current.user.is_admin? && (Current.user.site.nil? || Current.user.site.id != @site.id)
+      redirect_to sites_path, alert: "You don't have permission to access that site."
+    end
+  end
+
+  def ensure_document_access
+    if !Current.user.is_admin? && (Current.user.site.nil? || Current.user.site.documents.find(@document.id).nil?)
+      redirect_to sites_path, alert: "You don't have permission to perform that action on document."
+    end
+  end
+end

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -1,4 +1,8 @@
-class ConfigurationsController < ApplicationController
+class ConfigurationsController < AuthenticatedController
+  include Access
+
+  before_action :ensure_user_admin
+
   GOOGLE_API_SECRET_NAME = "asap-pdf/production/GOOGLE_AI_KEY"
   ANTHROPIC_API_SECRET_NAME = "asap-pdf/production/ANTHROPIC_KEY"
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -4,8 +4,6 @@ class DocumentsController < AuthenticatedController
   protect_from_forgery with: :exception
   skip_before_action :verify_authenticity_token, only: [:update_document_category, :update_accessibility_recommendation, :update_status, :update_notes, :update_summary_inference, :update_recommendation_inference]
   before_action :set_site, only: [:index, :modal_content]
-  # before_action :set_site, except: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference]
-  # before_action :set_document_for_update, only: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference, :update_status]
   before_action :set_document, except: [:index]
   before_action :ensure_user_site_access, only: [:index, :modal_content]
   before_action :ensure_document_access, except: [:index, :modal_content]

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,9 +1,10 @@
 class DocumentsController < AuthenticatedController
   protect_from_forgery with: :exception
   skip_before_action :verify_authenticity_token, only: [:update_document_category, :update_accessibility_recommendation, :update_status, :update_notes, :update_summary_inference, :update_recommendation_inference]
-  before_action :set_site, except: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference]
-  before_action :set_document_for_update, only: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference]
-  before_action :set_document, only: [:modal_content]
+  before_action :set_site, only: [:index, :modal_content]
+  # before_action :set_site, except: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference]
+  # before_action :set_document_for_update, only: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference, :update_status]
+  before_action :set_document, except: [:index]
 
   def modal_content
     render partial: "modal_content", locals: {document: @document}
@@ -56,10 +57,6 @@ class DocumentsController < AuthenticatedController
   end
 
   def update_status
-    @document = Document.joins(:site)
-      .where(sites: {user_id: Current.user.id})
-      .find(params[:id])
-
     # Set Unknown as default for empty values
     existing_recommendation = @document.accessibility_recommendation || Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION
     existing_category = @document.document_category || Document::DEFAULT_DOCUMENT_CATEGORY
@@ -96,17 +93,11 @@ class DocumentsController < AuthenticatedController
   private
 
   def set_site
-    @site = Current.user.sites.find(params[:site_id])
+    @site = Site.find(params[:site_id])
   end
 
   def set_document
-    @document = @site.documents.find(params[:id])
-  end
-
-  def set_document_for_update
-    @document = Document.joins(:site)
-      .where(sites: {user_id: Current.user.id})
-      .find(params[:id])
+    @document = Document.find(params[:id])
   end
 
   def sort_column

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,10 +1,14 @@
 class DocumentsController < AuthenticatedController
+  include Access
+
   protect_from_forgery with: :exception
   skip_before_action :verify_authenticity_token, only: [:update_document_category, :update_accessibility_recommendation, :update_status, :update_notes, :update_summary_inference, :update_recommendation_inference]
   before_action :set_site, only: [:index, :modal_content]
   # before_action :set_site, except: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference]
   # before_action :set_document_for_update, only: [:update_document_category, :update_accessibility_recommendation, :update_notes, :update_summary_inference, :update_recommendation_inference, :update_status]
   before_action :set_document, except: [:index]
+  before_action :ensure_user_site_access, only: [:index, :modal_content]
+  before_action :ensure_document_access, except: [:index, :modal_content]
 
   def modal_content
     render partial: "modal_content", locals: {document: @document}

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,7 @@ class DocumentsController < AuthenticatedController
   before_action :set_site, only: [:index, :modal_content]
   before_action :set_document, except: [:index]
   before_action :ensure_user_site_access, only: [:index, :modal_content]
-  before_action :ensure_document_access, except: [:index, :modal_content]
+  before_action :ensure_user_document_access, except: [:index, :modal_content]
 
   def modal_content
     render partial: "modal_content", locals: {document: @document}

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,6 +1,7 @@
 class SitesController < AuthenticatedController
+  include Access
   before_action :find_site, only: [:show, :edit, :update, :destroy]
-  before_action :ensure_user_owns_site, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_user_site_access, only: [:show, :edit, :update, :destroy]
 
   def index
     @sites = if Current.user.is_admin?
@@ -52,11 +53,5 @@ class SitesController < AuthenticatedController
 
   def find_site
     @site = Site.find(params[:id])
-  end
-
-  def ensure_user_owns_site
-    unless @site.id == Current.site.id
-      redirect_to sites_path, alert: "You don't have permission to access that site."
-    end
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,7 +3,11 @@ class SitesController < AuthenticatedController
   before_action :ensure_user_owns_site, only: [:show, :edit, :update, :destroy]
 
   def index
-    @sites = Current.user.sites.order(name: :asc)
+    @sites = if Current.user.is_admin?
+      Site.all
+    else
+      Current.user.site.nil? ? [] : [Current.user.site]
+    end
   end
 
   def show
@@ -11,11 +15,11 @@ class SitesController < AuthenticatedController
   end
 
   def new
-    @site = Current.user.sites.build
+    @site = Site.build
   end
 
   def create
-    @site = Current.user.sites.build(site_params)
+    @site = Site.build(site_params)
 
     if @site.save
       redirect_to sites_path, notice: "Site was successfully created."
@@ -51,7 +55,7 @@ class SitesController < AuthenticatedController
   end
 
   def ensure_user_owns_site
-    unless @site.user_id == Current.user.id
+    unless @site.id == Current.site.id
       redirect_to sites_path, alert: "You don't have permission to access that site."
     end
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,12 +1,12 @@
 class Site < ApplicationRecord
-  belongs_to :user
   has_many :documents, dependent: :destroy
+  has_many :users
 
   validates :name, presence: true
   validates :location, presence: true
   validates :primary_url, presence: true
-  validates :primary_url, uniqueness: {scope: :user_id}
-  validates :name, uniqueness: {scope: [:location, :user_id]}
+  # validates :primary_url, uniqueness: {scope: :user_id}
+  # validates :name, uniqueness: {scope: [:location, :user_id]}
   validate :ensure_safe_url
 
   def website
@@ -32,7 +32,7 @@ class Site < ApplicationRecord
   end
 
   def as_json(options = {})
-    super.except("user_id", "created_at", "updated_at")
+    super.except("created_at", "updated_at")
       .merge("s3_endpoint" => s3_endpoint)
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -2,11 +2,9 @@ class Site < ApplicationRecord
   has_many :documents, dependent: :destroy
   has_many :users
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :location, presence: true
-  validates :primary_url, presence: true
-  # validates :primary_url, uniqueness: {scope: :user_id}
-  # validates :name, uniqueness: {scope: [:location, :user_id]}
+  validates :primary_url, presence: true, uniqueness: true
   validate :ensure_safe_url
 
   def website

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
-  has_many :sites, dependent: :destroy
-  has_many :documents, through: :sites
+  has_many :documents, through: :site
+  belongs_to :site
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
-  has_many :documents, through: :site
-  belongs_to :site
+  belongs_to :site, optional: true
+  delegate :documents, to: :site, allow_nil: true
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,79 +1,81 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title><%= content_for(:title) || "PDF Audit Tool - Code for America" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-    <%= yield :head %>
-    <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" rel="stylesheet">
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
-    <%= favicon_link_tag asset_path('favicon.png') %>
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-  </head>
-  <body data-theme="autumn" class="min-h-screen bg-base-200">
-    <!-- Navigation -->
-    <nav class="bg-white shadow-md">
-      <div class="px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center h-20">
-          <!-- Logo -->
-          <div class="flex-shrink-0 flex items-center">
-            <%= image_tag "logo.png", class: "h-12", alt: "Code for America Logo" %>
-          </div>
-          <div class="relative" data-controller="dropdown">
-            <button data-action="click->dropdown#toggle" class="flex items-center space-x-2 text-gray-500 hover:text-gray-900 focus:outline-none">
-              <i class="fas fa-user-circle text-xl"></i>
-              <i class="fas fa-chevron-down text-sm"></i>
-            </button>
-            <div data-dropdown-target="menu" class="hidden absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
-              <div class="py-1">
-                <%= link_to sites_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
-                  <i class="fas fa-globe mr-2"></i>My Sites
-                <% end %>
-                <%= link_to edit_configuration_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
-                  <i class="fas fa-wand-magic-sparkles mr-2"></i>AI Settings
-                <% end %>
-                <%= button_to session_path, method: :delete, class: "w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
-                  <i class="fas fa-sign-out-alt mr-2"></i>Logout
-                <% end %>
-              </div>
-            </div>
+<head>
+  <title><%= content_for(:title) || "PDF Audit Tool - Code for America" %></title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= yield :head %>
+  <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" rel="stylesheet">
+  <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
+  <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+  <%= favicon_link_tag asset_path('favicon.png') %>
+  <%# Includes all stylesheet files in app/assets/stylesheets %>
+  <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+  <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+  <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+</head>
+<body data-theme="autumn" class="min-h-screen bg-base-200">
+<!-- Navigation -->
+<nav class="bg-white shadow-md">
+  <div class="px-4 sm:px-6 lg:px-8">
+    <div class="flex justify-between items-center h-20">
+      <!-- Logo -->
+      <div class="flex-shrink-0 flex items-center">
+        <%= image_tag "logo.png", class: "h-12", alt: "Code for America Logo" %>
+      </div>
+      <div class="relative" data-controller="dropdown">
+        <button data-action="click->dropdown#toggle" class="flex items-center space-x-2 text-gray-500 hover:text-gray-900 focus:outline-none">
+          <i class="fas fa-user-circle text-xl"></i>
+          <i class="fas fa-chevron-down text-sm"></i>
+        </button>
+        <div data-dropdown-target="menu" class="hidden absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+          <div class="py-1">
+            <%= link_to sites_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
+              <i class="fas fa-globe mr-2"></i>My Sites
+            <% end %>
+            <% if Current.user.is_admin? %>
+              <%= link_to edit_configuration_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
+                <i class="fas fa-wand-magic-sparkles mr-2"></i>AI Settings
+              <% end %>
+            <% end %>
+            <%= button_to session_path, method: :delete, class: "w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
+              <i class="fas fa-sign-out-alt mr-2"></i>Logout
+            <% end %>
           </div>
         </div>
       </div>
-    </nav>
-    <!-- Toast Messages -->
-    <div class="fixed top-4 right-4 z-50">
-      <% if flash[:notice] %>
-        <div data-controller="toast" class="transition-all duration-500 ease-in-out">
-          <div data-toast-target="container" class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 rounded shadow-lg">
-            <p class="font-medium">
-              <i class="fas fa-check-circle mr-2"></i>
-              <%= flash[:notice] %>
-            </p>
-          </div>
-        </div>
-      <% end %>
-      <% if flash[:alert] %>
-        <div data-controller="toast" class="transition-all duration-500 ease-in-out">
-          <div data-toast-target="container" class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 rounded shadow-lg">
-            <p class="font-medium">
-              <i class="fas fa-exclamation-circle mr-2"></i>
-              <%= flash[:alert] %>
-            </p>
-          </div>
-        </div>
-      <% end %>
     </div>
-    <!-- Main Content -->
-    <main class="mt-6">
-      <%= yield %>
-    </main>
-  </body>
+  </div>
+</nav>
+<!-- Toast Messages -->
+<div class="fixed top-4 right-4 z-50">
+  <% if flash[:notice] %>
+    <div data-controller="toast" class="transition-all duration-500 ease-in-out">
+      <div data-toast-target="container" class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 rounded shadow-lg">
+        <p class="font-medium">
+          <i class="fas fa-check-circle mr-2"></i>
+          <%= flash[:notice] %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+  <% if flash[:alert] %>
+    <div data-controller="toast" class="transition-all duration-500 ease-in-out">
+      <div data-toast-target="container" class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 rounded shadow-lg">
+        <p class="font-medium">
+          <i class="fas fa-exclamation-circle mr-2"></i>
+          <%= flash[:alert] %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+</div>
+<!-- Main Content -->
+<main class="mt-6">
+  <%= yield %>
+</main>
+</body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 </head>
 <body data-theme="autumn" class="min-h-screen bg-base-200">
 <!-- Navigation -->
-<nav class="bg-white shadow-md">
+<nav id="header" class="bg-white shadow-md">
   <div class="px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center h-20">
       <!-- Logo -->
@@ -36,7 +36,7 @@
             <%= link_to sites_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
               <i class="fas fa-globe mr-2"></i>My Sites
             <% end %>
-            <% if Current.user.is_admin? %>
+            <% if Current.user.present? && Current.user.is_admin? %>
               <%= link_to edit_configuration_path, class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" do %>
                 <i class="fas fa-wand-magic-sparkles mr-2"></i>AI Settings
               <% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -44,30 +44,32 @@
     </div>
   </div>
 </div>
-<!-- Add Site Modal -->
-<dialog id="add_site_modal" class="modal" data-controller="modal">
-  <div class="modal-box">
-    <h3 class="font-bold text-lg mb-4">Add New Site</h3>
-    <%= form_with(model: Site.new, class: "space-y-4", data: { turbo: true }) do |f| %>
-      <div class="form-control">
-        <%= f.label :name, class: "label" %>
-        <%= f.text_field :name, class: "input input-bordered", placeholder: "Enter site name", required: true %>
-      </div>
-      <div class="form-control">
-        <%= f.label :location, class: "label" %>
-        <%= f.text_field :location, class: "input input-bordered", placeholder: "Enter location", required: true %>
-      </div>
-      <div class="form-control">
-        <%= f.label :primary_url, "URL", class: "label" %>
-        <%= f.url_field :primary_url, class: "input input-bordered", placeholder: "https://example.com", required: true %>
-      </div>
-      <div class="modal-action">
-        <button type="button" class="btn btn-ghost mr-2" onclick="add_site_modal.close()">Cancel</button>
-        <%= f.submit "Add Site", class: "btn btn-neutral", data: { action: "click->modal#submitAndClose" } %>
-      </div>
-    <% end %>
-  </div>
-  <form method="dialog" class="modal-backdrop">
-    <button>close</button>
-  </form>
-</dialog>
+<% if Current.user.is_admin? %>
+  <!-- Add Site Modal -->
+  <dialog id="add_site_modal" class="modal" data-controller="modal">
+    <div class="modal-box">
+      <h3 class="font-bold text-lg mb-4">Add New Site</h3>
+      <%= form_with(model: Site.new, class: "space-y-4", data: { turbo: true }) do |f| %>
+        <div class="form-control">
+          <%= f.label :name, class: "label" %>
+          <%= f.text_field :name, class: "input input-bordered", placeholder: "Enter site name", required: true %>
+        </div>
+        <div class="form-control">
+          <%= f.label :location, class: "label" %>
+          <%= f.text_field :location, class: "input input-bordered", placeholder: "Enter location", required: true %>
+        </div>
+        <div class="form-control">
+          <%= f.label :primary_url, "URL", class: "label" %>
+          <%= f.url_field :primary_url, class: "input input-bordered", placeholder: "https://example.com", required: true %>
+        </div>
+        <div class="modal-action">
+          <button type="button" class="btn btn-ghost mr-2" onclick="add_site_modal.close()">Cancel</button>
+          <%= f.submit "Add Site", class: "btn btn-neutral", data: { action: "click->modal#submitAndClose" } %>
+        </div>
+      <% end %>
+    </div>
+    <form method="dialog" class="modal-backdrop">
+      <button>close</button>
+    </form>
+  </dialog>
+<% end %>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -3,7 +3,9 @@
     <div class="px-4 sm:px-6 lg:px-8">
       <div class="flex justify-between items-center">
         <h1 class="text-gray-600">My Sites</h1>
-        <button id="add-site-modal" onclick="add_site_modal.showModal()" class="btn btn-primary">Add Site</button>
+        <% if Current.user.is_admin? %>
+          <button id="add-site-modal" onclick="add_site_modal.showModal()" class="btn btn-primary">Add Site</button>
+        <% end %>
       </div>
     </div>
   </header>

--- a/db/migrate/20250414172602_move_site_to_user.rb
+++ b/db/migrate/20250414172602_move_site_to_user.rb
@@ -3,7 +3,7 @@ class MoveSiteToUser < ActiveRecord::Migration[8.0]
     # Remove user reference on site.
     remove_reference :sites, :user
     # Add site reference to user instead.
-    add_reference :users, :site, foreign_key: true
+    add_reference :users, :site, null: true, foreign_key: true
   end
 
   def down

--- a/db/migrate/20250414172602_move_site_to_user.rb
+++ b/db/migrate/20250414172602_move_site_to_user.rb
@@ -1,0 +1,14 @@
+class MoveSiteToUser < ActiveRecord::Migration[8.0]
+  def up
+    # Remove user reference on site.
+    remove_reference :sites, :user
+    # Add site reference to user instead.
+    add_reference :users, :site, foreign_key: true
+  end
+
+  def down
+    # Reverse the above.
+    remove_reference :users, :site
+    add_reference :sites, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20250414193153_add_admin_flag.rb
+++ b/db/migrate/20250414193153_add_admin_flag.rb
@@ -1,0 +1,5 @@
+class AddAdminFlag < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :is_admin, :boolean
+  end
+end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -3,14 +3,13 @@ require "zip"
 namespace :documents do
   desc "Bootstrap"
   task :bootstrap, [:file_name] => :environment do |t, args|
-    admin = User.first
+    User.first
 
     # Create Salt Lake City site
     slc = Site.find_or_create_by!(
       name: "SLC.gov",
       location: "Salt Lake City, UT",
-      primary_url: "https://www.slc.gov/",
-      user: admin
+      primary_url: "https://www.slc.gov/"
     )
     puts "Created site: #{slc.name}"
 
@@ -18,8 +17,7 @@ namespace :documents do
     san_rafael = Site.find_or_create_by!(
       name: "The City with a Mission",
       location: "San Rafael, CA",
-      primary_url: "https://www.cityofsanrafael.org/",
-      user: admin
+      primary_url: "https://www.cityofsanrafael.org/"
     )
     puts "Created site: #{san_rafael.name}"
 
@@ -27,16 +25,14 @@ namespace :documents do
     austin = Site.find_or_create_by!(
       name: "The Official Website of The City of Austin",
       location: "Austin, TX",
-      primary_url: "https://www.austintexas.gov/",
-      user: admin
+      primary_url: "https://www.austintexas.gov/"
     )
     puts "Created site: #{austin.name}"
 
     ga = Site.find_or_create_by!(
       name: "georgia.gov",
       location: "Georgia",
-      primary_url: "https://georgia.gov/",
-      user: admin
+      primary_url: "https://georgia.gov/"
     )
     puts "Created site: #{ga.name}"
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -3,6 +3,7 @@ namespace :users do
   task :create_admin, [:password] => :environment do |t, args|
     User.find_or_create_by!(email_address: "admin@codeforamerica.org") do |user|
       user.password = args.password
+      user.is_admin = true
       puts "Created test user: admin@codeforamerica.org / #{args.password}"
     end
   end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :site do
-    name { "Example Site #{(0...8).map { (65 + rand(26)).chr }.join}" }
+    name { "Example Site #{(0...8).map { rand(65..90).chr }.join}" }
     location { "Example Location" }
-    primary_url { "http://#{(0...8).map { (65 + rand(26)).chr }.join}.example.com" }
+    primary_url { "http://#{(0...8).map { rand(65..90).chr }.join}.example.com" }
   end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -3,6 +3,5 @@ FactoryBot.define do
     name { "Example Site" }
     location { "Example Location" }
     primary_url { "http://example.com" }
-    user
   end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :site do
-    name { "Example Site" }
+    name { "Example Site #{(0...8).map { (65 + rand(26)).chr }.join}" }
     location { "Example Location" }
-    primary_url { "http://example.com" }
+    primary_url { "http://#{(0...8).map { (65 + rand(26)).chr }.join}.example.com" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     email_address { "user#{rand(1000)}@example.com" }
     password { "password" }
+    site
   end
 end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "admins can see admin pages", type: :feature do
+  before :each do
+    @current_user = User.create(email_address: "user@example.com", password: "password")
+    login_user(@current_user)
+  end
+
+  it "admins can create and see sites" do
+    visit "/"
+    within("#header") do
+      user_menu = find("[data-action='click->dropdown#toggle']")
+      user_menu.click
+    end
+    within("div[data-dropdown-target='menu']") do
+      expect(page).to have_content "My Sites"
+      expect(page).to have_no_content "AI Settings"
+    end
+    visit "/configuration/edit"
+    expect(current_path).to eq("/sites")
+    expect(page).to have_content "You don't have permission to access that page."
+    @current_user.is_admin = true
+    @current_user.save
+    visit "/"
+    within("#header") do
+      user_menu = find("[data-action='click->dropdown#toggle']")
+      user_menu.click
+      click_link("AI Settings")
+    end
+    expect(current_path).to eq("/configuration/edit")
+    expect(page).to have_content "AI Configuration Settings"
+  end
+end

--- a/spec/features/document_spec.rb
+++ b/spec/features/document_spec.rb
@@ -2,18 +2,21 @@ require "rails_helper"
 
 describe "documents function as expected", js: true, type: :feature do
   before :each do
-    @current_user = User.create(email_address: "user@example.com", password: "password")
+    @current_user = User.create(email_address: "user@example.com", password: "password1231231232wordpass")
     login_user(@current_user)
   end
 
   it "documents belong to a site and may be manipulated" do
     # Create our test setup
-    site = Site.create(name: "City of Denver", location: "Colorado", primary_url: "https://denvergov.org", user_id: @current_user.id)
-    Document.create(url: "http://denvergov.org/docs/example.pdf", file_name: "example.pdf", document_category: "Agenda", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id)
-    site = Site.create(name: "City of Boulder", location: "Colorado", primary_url: "https://bouldercolorado.gov", user_id: @current_user.id)
-    Document.create(url: "https://bouldercolorado.gov/docs/rtd_contract.pdf", file_name: "rtd_contract.pdf", document_category: "Agreement", document_category_confidence: 0.73, accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id)
-    Document.create(url: "https://bouldercolorado.gov/docs/teahouse_rules.pdf", file_name: "teahouse_rules.pdf", document_category: "Notice", document_category_confidence: 0.71, accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id)
-    Document.create(url: "https://bouldercolorado.gov/docs/farmers_market_2023.pdf", file_name: "farmers_market_2023.pdf", document_category: "Notice", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id, modification_date: "2024-10-01")
+    site = Site.create(name: "City of Denver", location: "Colorado", primary_url: "https://denvergov.org")
+    @current_user.site = site
+    @current_user.save!
+    Document.create(url: "http://denvergov.org/docs/example.pdf", file_name: "example.pdf", document_category: "Agenda", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site: site)
+    site = Site.create(name: "City of Boulder", location: "Colorado", primary_url: "https://bouldercolorado.gov")
+    boulder_user = User.create(email_address: "boulder@example.com", password: "password1231231232wordpass", site: site)
+    Document.create(url: "https://bouldercolorado.gov/docs/rtd_contract.pdf", file_name: "rtd_contract.pdf", document_category: "Agreement", document_category_confidence: 0.73, accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site: site)
+    Document.create(url: "https://bouldercolorado.gov/docs/teahouse_rules.pdf", file_name: "teahouse_rules.pdf", document_category: "Notice", document_category_confidence: 0.71, accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site: site)
+    Document.create(url: "https://bouldercolorado.gov/docs/farmers_market_2023.pdf", file_name: "farmers_market_2023.pdf", document_category: "Notice", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site: site, modification_date: "2024-10-01")
     # Test single document and document editing.
     visit "/"
     click_link("City of Denver")
@@ -56,6 +59,8 @@ describe "documents function as expected", js: true, type: :feature do
       expect(page).to have_content "In Review\n0"
       expect(page).to have_content "Done\n1"
     end
+    Session.last.destroy
+    login_user(boulder_user)
     # Test multiple documents and filtration.
     visit "/"
     click_link("City of Boulder")
@@ -137,7 +142,9 @@ describe "documents function as expected", js: true, type: :feature do
 
   it "documents have some tabs" do
     # Create our test setup
-    site = Site.create(name: "City of Denver", location: "Colorado", primary_url: "https://denvergov.org", user_id: @current_user.id)
+    site = Site.create(name: "City of Denver", location: "Colorado", primary_url: "https://denvergov.org")
+    @current_user.site = site
+    @current_user.save!
     doc = Document.create(url: "http://denvergov.org/docs/example.pdf", file_name: "example.pdf", document_category: "Agenda", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id)
     visit "/"
     click_link("City of Denver")

--- a/spec/features/site_spec.rb
+++ b/spec/features/site_spec.rb
@@ -16,6 +16,11 @@ describe "sites function as expected", type: :feature do
       fill_in "URL", with: "https://www.denvergov.org"
       click_button "Add Site"
     end
+    # @todo remove after adding site UI to user.
+    @current_user.site = Site.last
+    @current_user.save!
+    visit "/"
+    # end todo.
     within("#sites-grid") do
       expect(page).to have_content "City of Denver"
       expect(page).to have_content "Colorado"
@@ -29,9 +34,10 @@ describe "sites function as expected", type: :feature do
   end
 
   it "cannot see someone else's site" do
-    user = User.create(email_address: "somebodyelse@example.com", password: "password")
-    site = Site.create(name: "Boulder", location: "Colorado", primary_url: "https://bouldercolorado.gov", user_id: user.id)
+    site = Site.create(name: "Boulder", location: "Colorado", primary_url: "https://bouldercolorado.gov")
+    User.create(email_address: "somebodyelse@example.com", password: "password", site: site)
     visit "/sites/#{site.id}/documents"
-    expect(page).to have_content "ActiveRecord::RecordNotFound in DocumentsController#index"
+    expect(current_path).to eq("/sites")
+    expect(page).to have_content("You don't have permission to access that site.")
   end
 end

--- a/spec/features/site_spec.rb
+++ b/spec/features/site_spec.rb
@@ -34,7 +34,7 @@ describe "sites function as expected", type: :feature do
 
   it "non-admins can see only their sites" do
     site = Site.create(name: "City of Denver", primary_url: "https://www.denvergov.org", location: "Colorado")
-    @current_user.site=site
+    @current_user.site = site
     @current_user.save
     Site.create(name: "City of Boulder", primary_url: "https://www.bouldercolorado.org", location: "Colorado")
     visit "/"
@@ -52,9 +52,9 @@ describe "sites function as expected", type: :feature do
 
   it "multiple users can access the same site" do
     site = Site.create(name: "City of Denver", primary_url: "https://www.denvergov.org", location: "Colorado")
-    @current_user.site=site
+    @current_user.site = site
     @current_user.save
-    other_user =  User.create(email_address: "example_2@example.com", password: "password", site: site)
+    other_user = User.create(email_address: "example_2@example.com", password: "password", site: site)
     visit "/"
     within("#sites-grid") do
       expect(page).to have_content "City of Denver"

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Site, type: :model do
   subject { build(:site) }
-  let(:user) { create(:user, site: user) }
 
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:documents) }
@@ -12,6 +11,9 @@ RSpec.describe Site, type: :model do
   it { is_expected.to validate_presence_of(:primary_url) }
   it { is_expected.to allow_value("http://example.com").for(:primary_url) }
   it { is_expected.not_to allow_value("invalid_url").for(:primary_url) }
+
+  it { is_expected.to validate_uniqueness_of(:primary_url) }
+  it { is_expected.to validate_uniqueness_of(:name) }
 
   describe "S3 functionality" do
     describe "#s3_endpoint_prefix" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Site, type: :model do
-  let(:user) { create(:user) }
-  subject { build(:site, user: user) }
+  subject { build(:site) }
+  let(:user) { create(:user, site: user) }
 
-  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:documents) }
 
   it { is_expected.to validate_presence_of(:name) }
@@ -12,25 +12,6 @@ RSpec.describe Site, type: :model do
   it { is_expected.to validate_presence_of(:primary_url) }
   it { is_expected.to allow_value("http://example.com").for(:primary_url) }
   it { is_expected.not_to allow_value("invalid_url").for(:primary_url) }
-
-  it { is_expected.to validate_uniqueness_of(:primary_url).scoped_to(:user_id) }
-  it { is_expected.to validate_uniqueness_of(:name).scoped_to([:location, :user_id]) }
-
-  describe "uniqueness validations" do
-    let(:user) { create(:user) }
-
-    it "validates uniqueness of primary_url scoped to user_id" do
-      create(:site, primary_url: "http://example.com", user: user)
-      site = build(:site, primary_url: "http://example.com", user: user)
-      expect(site).not_to be_valid
-    end
-
-    it "validates uniqueness of name scoped to location and user_id" do
-      create(:site, name: "Example Site", location: "Example Location", user: user)
-      site = build(:site, name: "Example Site", location: "Example Location", user: user)
-      expect(site).not_to be_valid
-    end
-  end
 
   describe "S3 functionality" do
     describe "#s3_endpoint_prefix" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe User, type: :model do
 
   it { is_expected.to have_secure_password }
   it { is_expected.to have_many(:sessions).dependent(:destroy) }
-  it { is_expected.to have_many(:sites).dependent(:destroy) }
-  it { is_expected.to have_many(:documents).through(:sites) }
+  it { is_expected.to belong_to(:site).optional(true) }
+  it { is_expected.to delegate_method(:documents).to(:site).allow_nil }
 
   it { is_expected.to validate_presence_of(:email_address) }
   it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }


### PR DESCRIPTION
This PR adds support for multiple users to access a single site. It also adds an admin flag to the user model, which allows access to all sites. I decided to take the simpler approach of having users relate to sites, rather than creating a lookup table to relate them. We could always do that later, if we need it. Here is a break down of the specific changes:

* Removes user_id column and related ActiveRecord associations from sites.
* Adds site_id column and related ActiveRecord associations on user.
* Adds is_admin flag on user (to be set manually).
* Hides "Add Site" and "AI Settings" areas from non-admin users.
* Changes sites uniqueness settings to be universal rather than contextualized to users. Sites names and primary urls must now be unique.
* Adjusted and added test coverage.