### PR TITLE
1337 fix document request regressions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 gem "cssbundling-rails", "~> 1.4.3"
 gem "csv"
-gem "rest-client"
+gem "httpparty"
 gem "rubyzip"
 gem "smarter_csv"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,6 @@ GEM
     docile (1.4.1)
     dockerfile-rails (1.7.9)
       rails (>= 3.0.0)
-    domain_name (0.6.20240107)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
@@ -181,9 +180,6 @@ GEM
     grape-swagger (2.1.2)
       grape (>= 1.7, < 3.0)
       rack-test (~> 2)
-    http-accept (1.7.0)
-    http-cookie (1.0.8)
-      domain_name (~> 0.5)
     httparty (0.23.1)
       csv
       mini_mime (>= 1.0.0)
@@ -228,10 +224,6 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
-    mime-types (3.6.1)
-      logger
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0318)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -250,7 +242,6 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.18.7-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -352,11 +343,6 @@ GEM
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.4.1)
     rouge (4.5.1)
     rspec (3.13.0)
@@ -538,7 +524,6 @@ DEPENDENCIES
   rails (~> 8.0.1)
   rails-controller-testing
   redis (~> 5.4.0)
-  rest-client
   rspec (~> 3.13)
   rspec-rails (~> 7.1)
   ruby-lsp (~> 0.23)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,12 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    httpparty (0.2.0)
+      httparty (> 0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     iniparse (1.5.0)
@@ -229,6 +235,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     mustermann-grape (1.1.0)
@@ -519,6 +527,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.4)
   grape (~> 2.3)
   grape-swagger
+  httpparty
   jsbundling-rails
   kaminari (~> 1.2)
   overcommit (~> 0.67.1)

--- a/app/helpers/url_decoded_attribute_helper.rb
+++ b/app/helpers/url_decoded_attribute_helper.rb
@@ -2,7 +2,7 @@ module UrlDecodedAttributeHelper
   def url_decoded_attribute(attribute)
     define_method(attribute) do
       return nil if self[attribute].nil?
-      CGI.unescape(self[attribute])
+      URI::DEFAULT_PARSER.unescape(self[attribute])
     end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -67,10 +67,6 @@ class Document < ApplicationRecord
 
   before_validation :set_defaults
 
-  def safe_file_name
-    file_name.gsub(/[^a-zA-Z0-9_-]/, "-")
-  end
-
   def summary
     summary = document_inferences.find_by(inference_type: "summary")
     summary.present? ? summary.inference_value : nil

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -97,10 +97,7 @@ class Site < ApplicationRecord
         skipped = 0
         chunk.each do |row|
           row = row.stringify_keys
-          # Encode URL while preserving basic URL structure
-          encoded_url = URI.encode_www_form_component(row["url"])
-            .gsub("%3A", ":") # Restore colons
-            .gsub("%2F", "/") # Restore forward slashes
+          encoded_url = URI::DEFAULT_PARSER.escape(row["url"])
 
           # Parse file size (remove KB suffix and convert to float)
           file_size = row["file_size"]&.gsub("KB", "")&.strip&.to_f

--- a/app/views/documents/_modal_content.html.erb
+++ b/app/views/documents/_modal_content.html.erb
@@ -31,7 +31,7 @@
           </button>
         <% end %>
       </div>
-      <iframe src="<%= serve_file_content_document_path(@document.id,  @document.safe_file_name) %>?pagemode=none&toolbar=1" class="w-full h-[calc(90vh-8rem)]" type="application/pdf"></iframe>
+      <iframe src="<%= serve_file_content_document_path(@document.id,  @document.file_name) %>?pagemode=none&toolbar=1" class="w-full h-[calc(90vh-8rem)]" type="application/pdf"></iframe>
     </div>
     <!-- PDF Details View -->
     <div data-modal-target="metadataView" class="hidden h-[calc(90vh-12rem)] overflow-y-auto bg-white rounded-md">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       patch :update_notes
       patch :update_summary_inference
       patch :update_recommendation_inference
-      get "serve_content/:filename", to: "documents#serve_document_url", as: "serve_file_content"
+      get "serve_content/:filename", to: "documents#serve_document_url", as: "serve_file_content", constraints: {filename: /[^\/]+/}
     end
   end
 

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-import urllib
+import shutil
 
 import boto3
 import fitz
@@ -49,9 +49,11 @@ def get_secret(secret_name: str, local_mode: bool) -> str:
 def get_file(url: str, output_path: str) -> str:
     file_name = os.path.basename(url)
     local_path = f"{output_path}/{file_name}"
-    opener = urllib.request.URLopener()
-    opener.addheader("User-Agent", "cfa:asap-pdf")
-    opener.retrieve(url, local_path)
+    headers = {"User-Agent": "cfa:asap-pdf"}
+    with requests.get(url, headers=headers, stream=True) as response:
+        response.raise_for_status()
+        with open(f"{output_path}/{file_name}", 'wb') as file:
+            shutil.copyfileobj(response.raw, file)
     return local_path
 
 

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -52,7 +52,7 @@ def get_file(url: str, output_path: str) -> str:
     headers = {"User-Agent": "cfa:asap-pdf"}
     with requests.get(url, headers=headers, stream=True) as response:
         response.raise_for_status()
-        with open(f"{output_path}/{file_name}", 'wb') as file:
+        with open(f"{output_path}/{file_name}", "wb") as file:
             shutil.copyfileobj(response.raw, file)
     return local_path
 

--- a/spec/features/document_spec.rb
+++ b/spec/features/document_spec.rb
@@ -144,19 +144,19 @@ describe "documents function as expected", js: true, type: :feature do
     site = Site.create(name: "City of Denver", location: "Colorado", primary_url: "https://denvergov.org")
     @current_user.site = site
     @current_user.save!
-    doc = Document.create(url: "http://denvergov.org/docs/example.pdf", file_name: "example.pdf", document_category: "Agenda", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id)
-    iframe_src = serve_file_content_document_path(doc.id, doc.safe_file_name) + "?pagemode=none&toolbar=1"
+    doc = Document.create(url: "http://denvergov.org/docs/ex.ample.pdf", file_name: "ex.ample.pdf", document_category: "Agenda", accessibility_recommendation: Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION, site_id: site.id)
+    iframe_src = serve_file_content_document_path(doc.id, doc.file_name) + "?pagemode=none&toolbar=1"
     visit "/"
     click_link("City of Denver")
     # Test out the modal and tabs.
     within("#document-list") do
-      click_button "example.pdf"
+      click_button "ex.ample.pdf"
     end
     # Wait for modal to open.
     expect(page).to have_selector("#document-list .modal", visible: true, wait: 5)
     within("#document-list .modal") do
       # Assess default tab.
-      expect(page).to have_content "example.pdf"
+      expect(page).to have_content "ex.ample.pdf"
       expect(page).to have_css("[data-action='modal#showSummaryView'].tab-active")
       # Later we'll check to see if the button is gone.
       expect(page).to have_content "Summarize Document"
@@ -166,7 +166,7 @@ describe "documents function as expected", js: true, type: :feature do
       expect(page).to have_no_css("[data-action='modal#showSummaryView'].tab-active")
       expect(page).to have_css("[data-action='modal#showMetadataView'].tab-active")
       expect(page).to have_no_css("iframe[src='#{iframe_src}']")
-      expect(page).to have_content "File Name\nexample.pdf"
+      expect(page).to have_content "File Name\nex.ample.pdf"
       expect(page).to have_content "Type\nAgenda"
       expect(page).to have_content "Decision\nNeeds Decision"
       # Add a note.
@@ -181,7 +181,7 @@ describe "documents function as expected", js: true, type: :feature do
     visit "/"
     click_link("City of Denver")
     within("#document-list") do
-      click_button "example.pdf"
+      click_button "ex.ample.pdf"
     end
     expect(page).to have_selector("#document-list .modal", visible: true, wait: 5)
     within("#document-list .modal") do
@@ -203,7 +203,7 @@ describe "documents function as expected", js: true, type: :feature do
     visit "/"
     click_link("City of Denver")
     within("#document-list") do
-      click_button "example.pdf"
+      click_button "ex.ample.pdf"
     end
     expect(page).to have_selector("#document-list .modal", visible: true, wait: 5)
     within("#document-list .modal") do
@@ -223,7 +223,7 @@ describe "documents function as expected", js: true, type: :feature do
     visit "/"
     click_link("City of Denver")
     within("#document-list") do
-      click_button "example.pdf"
+      click_button "ex.ample.pdf"
     end
     expect(page).to have_selector("#document-list .modal", visible: true, wait: 5)
     within("#document-list .modal") do


### PR DESCRIPTION
We were originally using the rest-client library, [which is no longer maintained](https://github.com/rest-client/rest-client/issues/830). The client doesn't support 308 redirects that we are running into. We also still have problems with special characters in urls. This PR addresses these issues.

* Use HTTPParty instead of rest-client to serve files.
* Standardize url encoding and decoding functions.
* Allow for filenames that contain multiple dots.
* Update python components to also follow 308 redirects.