### PR TITLE
Integrate pdf complexity into application

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -19,6 +19,7 @@ class DocumentsController < AuthenticatedController
       .by_category(params[:category])
       .by_decision_type(params[:accessibility_recommendation])
       .by_department(params[:department])
+      .by_complexity(params[:complexity])
       .by_date_range(params[:start_date], params[:end_date])
       .order(sort_column => sort_direction)
       .page(params[:page])
@@ -32,6 +33,8 @@ class DocumentsController < AuthenticatedController
       end
     }.to_h { |a| [a.nil? ? "None" : a, a.nil? ? "None" : a] }
     @show_departments_filter = @site.documents.where.not(department: [nil, ""]).any?
+    @document_complexities = Document::COMPLEXITIES
+    @show_complexities_filter = @site.documents.where.not(complexity: [nil, ""]).any?
     @total_documents = @documents.total_count
     @status_values = Document::STATUSES.reject { |a| a == (params[:status].present? ? params[:status] : Document::DEFAULT_STATUS) }
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,6 +31,12 @@ class Document < ApplicationRecord
     where(department: department)
   }
 
+  scope :by_complexity, ->(complexity) {
+    return all if complexity.blank?
+    complexity = (complexity == "None") ? [nil, ""] : complexity
+    where(complexity: complexity)
+  }
+
   scope :by_date_range, ->(start_date, end_date) {
     scope = all
     scope = scope.where("modification_date >= ?", start_date) if start_date.present?
@@ -65,6 +71,11 @@ class Document < ApplicationRecord
     "Convert" => "Convert PDF to web content",
     "Remove" => "Remove PDF from website"
   }.freeze
+
+  SIMPLE_STATUS = "Simple".freeze
+  COMPLEX_STATUS = "Complex".freeze
+
+  COMPLEXITIES = [SIMPLE_STATUS, COMPLEX_STATUS].freeze
 
   validates :file_name, presence: true
   validates :url, presence: true, format: {with: URI::DEFAULT_PARSER.make_regexp}

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -155,6 +155,10 @@ class Site < ApplicationRecord
             urls = row["source"].scan(/'([^']+)'/).flatten
             urls.empty? ? nil : urls
           end
+
+          complexity = if ((row["predicted_category"] != "Form") &&
+            (row["number_of_tables"]&.to_i == 0) &&
+            (row["number_of_images"]&.to_i == 0)) ? "Simple" : "Complex"
           documents << {
             url: encoded_url,
             file_name: row["file_name"],
@@ -171,7 +175,8 @@ class Site < ApplicationRecord
             predicted_category_confidence: row["predicted_category_confidence"],
             number_of_pages: row["number_of_pages"]&.to_i,
             number_of_tables: row["number_of_tables"]&.to_i,
-            number_of_images: row["number_of_images"]&.to_i
+            number_of_images: row["number_of_images"]&.to_i,
+            complexity: complexity
           }
         rescue URI::InvalidURIError => e
           puts "Skipping invalid URL: #{row["url"]}"

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -156,9 +156,6 @@ class Site < ApplicationRecord
             urls.empty? ? nil : urls
           end
 
-          complexity = if ((row["predicted_category"] != "Form") &&
-            (row["number_of_tables"]&.to_i == 0) &&
-            (row["number_of_images"]&.to_i == 0)) ? "Simple" : "Complex"
           documents << {
             url: encoded_url,
             file_name: row["file_name"],
@@ -175,8 +172,7 @@ class Site < ApplicationRecord
             predicted_category_confidence: row["predicted_category_confidence"],
             number_of_pages: row["number_of_pages"]&.to_i,
             number_of_tables: row["number_of_tables"]&.to_i,
-            number_of_images: row["number_of_images"]&.to_i,
-            complexity: complexity
+            number_of_images: row["number_of_images"]&.to_i
           }
         rescue URI::InvalidURIError => e
           puts "Skipping invalid URL: #{row["url"]}"

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -26,7 +26,7 @@
             <% end %>
           </nav>
         </div>
-        <%= render partial: "shared/filter", locals: { site: @site, documents: @documents, document_categories: @document_categories, document_decisions: @document_decisions, document_departments: @document_departments, show_departments_filter: @show_departments_filter, total_documents: @total_documents } %>
+        <%= render partial: "shared/filter", locals: { site: @site, documents: @documents, document_categories: @document_categories, document_decisions: @document_decisions, document_departments: @document_departments, show_departments_filter: @show_departments_filter, document_complexities: @document_complexities, show_complexities_filter: @show_complexities_filter, total_documents: @total_documents } %>
       </div>
       <div id="document-list" class="px-4 sm:px-0 space-y-0">
         <div class="bg-gray-50 shadow-sm rounded-t-lg px-6 py-4  border-b-gray-200 border-b

--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -50,6 +50,16 @@
                            class: "select-custom w-full" %>
           </div>
         <% end %>
+        <% if show_complexities_filter %>
+          <div>
+            <label class="label">
+              <span class="label-text">Complexity</span>
+            </label>
+            <%= select_tag :complexity,
+                           options_for_select([['All Documents', '']] + document_complexities.map { |c| [c.to_s.titleize, c] }, params[:complexity]),
+                           class: "select-custom w-full" %>
+          </div>
+        <% end %>
       </div>
       <div class="flex justify-end pt-4">
         <div>

--- a/db/migrate/20250507231759_add_complexity.rb
+++ b/db/migrate/20250507231759_add_complexity.rb
@@ -1,0 +1,5 @@
+class AddComplexity < ActiveRecord::Migration[8.0]
+  def change
+    add_column :documents, :complexity, :text
+  end
+end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -157,4 +157,17 @@ namespace :documents do
       end
     end
   end
+
+  desc "Add PDF complexity."
+  task add_pdf_complexity: :environment do
+    Document.find_each do |document|
+      unless document.number_of_tables.nil? || document.number_of_images.nil?
+        complexity = ((document.document_category != "Form") &&
+          (document.number_of_tables == 0) &&
+          (document.number_of_images == 0)) ? Document::SIMPLE_STATUS : Document::COMPLEX_STATUS
+        document.complexity = complexity
+        document.save
+      end
+    end
+  end
 end

--- a/spec/features/document_spec.rb
+++ b/spec/features/document_spec.rb
@@ -153,7 +153,6 @@ describe "documents function as expected", js: true, type: :feature do
     visit "/"
     click_link("City of Boulder")
     within("#sidebar") do
-      # sleep(120)
       expect(page).to have_selector "#complexity"
       expect(page).to have_selector "#complexity option[value='Simple']"
       expect(page).to have_selector "#complexity option[value='Complex']"

--- a/spec/features/document_spec.rb
+++ b/spec/features/document_spec.rb
@@ -141,6 +141,39 @@ describe "documents function as expected", js: true, type: :feature do
       expect(page).to have_content "rtd_contract.pdf"
       expect(page).to have_content "farmers_market_2023.pdf"
     end
+    # Test complexity filter.
+    within("#sidebar") do
+      expect(page).to have_no_content "Complexity"
+      expect(page).to have_no_content "#complexity"
+    end
+    rtd_contract_doc.complexity = Document::SIMPLE_STATUS
+    rtd_contract_doc.save!
+    teahouse_doc.complexity = Document::COMPLEX_STATUS
+    teahouse_doc.save!
+    visit "/"
+    click_link("City of Boulder")
+    within("#sidebar") do
+      # sleep(120)
+      expect(page).to have_selector "#complexity"
+      expect(page).to have_selector "#complexity option[value='Simple']"
+      expect(page).to have_selector "#complexity option[value='Complex']"
+      find("#complexity option[value='']").click
+      click_button "Apply Filters"
+    end
+    within("#document-list") do
+      expect(page).to have_content "teahouse_rules.pdf"
+      expect(page).to have_content "rtd_contract.pdf"
+      expect(page).to have_content "farmers_market_2023.pdf"
+    end
+    within("#sidebar") do
+      find("#complexity option[value='Simple']").click
+      click_button "Apply Filters"
+    end
+    within("#document-list") do
+      expect(page).to have_no_content "teahouse_rules.pdf"
+      expect(page).to have_no_content "farmers_market_2023.pdf"
+      expect(page).to have_content "rtd_contract.pdf"
+    end
     # Test sorting
     within("#sidebar") do
       click_link "Clear"


### PR DESCRIPTION
Addresses [ASAP-136](https://codeforamerica.atlassian.net/browse/ASAP-136?atlOrigin=eyJpIjoiZDc4OTYwYzE2ODMzNDU4NWEzZDRkOTUyZDMzNTRhZjUiLCJwIjoiaiJ9). Adds simple / complex labels onto documents and allows the user to filter by them.

Two outstanding questions for feedback:
(1) Would adding this as a column to the main list view be helpful? We could add a hover over to explain how we constructed this score.
(2) What should the default behavior be called? I struggled with following other conventions (e.g., from "Document Type" -> "All Types", to "Complexity" -> "All Complexities" felt too wordy). 
<img width="233" alt="image" src="https://github.com/user-attachments/assets/fbe15854-12a9-4c4f-bc27-00cc8de222f7" />


[ASAP-136]: https://codeforamerica.atlassian.net/browse/ASAP-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ