### PR TITLE
1337 light responsive theming

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -57,6 +57,16 @@
   top: 10px;
 }
 
+.animate-up {
+  transition: bottom;
+  transition-duration: 0.25s;
+  bottom: 0px;
+}
+
+.off-screen-bottom {
+  bottom: -400px;
+}
+
 @layer base {
   h1 {
     @apply text-2xl font-medium text-gray-500 leading-tight text-base-content;

--- a/app/javascript/controllers/bulk_edit_controller.js
+++ b/app/javascript/controllers/bulk_edit_controller.js
@@ -80,11 +80,9 @@ export default class extends Controller {
 
     updateActionBar() {
         if (this.store.checked > 0) {
-            // this.actionsTarget.classList.remove("hidden");
             this.actionsTarget.classList.remove("off-screen-bottom");
         } else {
             this.actionsTarget.classList.add("off-screen-bottom")
-            // this.actionsTarget.classList.add("hidden")
         }
         const counter = this.actionsTarget.querySelector('.checked-count span')
         counter.innerHTML = this.store.checked

--- a/app/javascript/controllers/bulk_edit_controller.js
+++ b/app/javascript/controllers/bulk_edit_controller.js
@@ -80,9 +80,11 @@ export default class extends Controller {
 
     updateActionBar() {
         if (this.store.checked > 0) {
-            this.actionsTarget.classList.remove("hidden");
+            // this.actionsTarget.classList.remove("hidden");
+            this.actionsTarget.classList.remove("off-screen-bottom");
         } else {
-            this.actionsTarget.classList.add("hidden")
+            this.actionsTarget.classList.add("off-screen-bottom")
+            // this.actionsTarget.classList.add("hidden")
         }
         const counter = this.actionsTarget.querySelector('.checked-count span')
         counter.innerHTML = this.store.checked

--- a/app/views/documents/_modal_content.html.erb
+++ b/app/views/documents/_modal_content.html.erb
@@ -1,20 +1,20 @@
 <%= turbo_frame_tag "modal_content_#{document.id}" do %>
   <div class="flex flex-col space-y-4">
     <!-- Tab Navigation -->
-    <div class="tabs tabs-bordered">
-      <button data-modal-target="summaryButton" data-action="modal#showSummaryView" class="tab tab-bordered tab-active">
+    <div class="tabs tabs-bordered h-auto">
+      <button data-modal-target="summaryButton" data-action="modal#showSummaryView" class="tab tab-bordered tab-active leading-none h-16 md:h-8">
         <i class="fas fa-file-pdf mr-1"></i>
         Summary
       </button>
-      <button data-modal-target="metadataButton" data-action="modal#showMetadataView" class="tab tab-bordered">
+      <button data-modal-target="metadataButton" data-action="modal#showMetadataView" class="tab tab-bordered leading-none h-16 md:h-8">
         <i class="fas fa-info-circle mr-1"></i>
         PDF Details
       </button>
-      <button data-modal-target="recommendationButton" data-action="modal#showReccomendationView" class="tab tab-bordered">
+      <button data-modal-target="recommendationButton" data-action="modal#showReccomendationView" class="tab tab-bordered leading-none h-16 md:h-8">
         <i class="fas fa-wand-sparkles mr-1"></i>
         AI Exception Check
       </button>
-      <button data-modal-target="historyButton" data-action="modal#showHistoryView" class="tab tab-bordered">
+      <button data-modal-target="historyButton" data-action="modal#showHistoryView" class="tab tab-bordered leading-none h-16 md:h-8">
         <i class="fas fa-history mr-1"></i>
         History
       </button>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -2,7 +2,7 @@
   <%= tag.meta name: "site-id", content: @site.id %>
 <% end %>
 <div class="py-6">
-  <div class="mx-auto sm:px-6 lg:px-8">
+  <div class="mx-auto px-6 lg:px-8">
     <div class="grid grid-cols-1 lg:grid-cols-[250px_1fr] lg:gap-6">
       <div id="sidebar" class="space-y-6 mb-6">
         <%= render partial: "shared/site_navigation", locals: { site: @site } %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -2,9 +2,9 @@
   <%= tag.meta name: "site-id", content: @site.id %>
 <% end %>
 <div class="py-6">
-  <div class="mx-auto sm:px-6 lg:px-8">
-    <div class="grid grid-cols-[250px_1fr] gap-6">
-      <div id="sidebar" class="space-y-6">
+  <div class="mx-auto px-6 lg:px-8">
+    <div class="grid grid-cols-1 lg:grid-cols-[250px_1fr] lg:gap-6">
+      <div id="sidebar" class="space-y-6 mb-6">
         <div class="bg-white shadow-sm rounded-lg h-fit">
           <nav class="p-4 space-y-2">
             <% Document::STATUSES.each do |status_val| %>
@@ -28,14 +28,13 @@
         </div>
         <%= render partial: "shared/filter", locals: { site: @site, documents: @documents, document_categories: @document_categories, document_decisions: @document_decisions, document_departments: @document_departments, show_departments_filter: @show_departments_filter, document_complexities: @document_complexities, show_complexities_filter: @show_complexities_filter, total_documents: @total_documents } %>
       </div>
-      <div id="document-list" class="px-4 sm:px-0 space-y-0">
-        <div class="bg-gray-50 shadow-sm rounded-t-lg px-6 py-4  border-b-gray-200 border-b
-">
+      <div id="document-list" class="px-0 space-y-0 md:overflow-x-scroll">
+        <div class="bg-gray-50 shadow-sm rounded-t-lg px-6 py-4  border-b-gray-200 border-b">
           <div class="flex justify-between items-center">
             <h1 class="text-lg font-medium"><%= @site.location %>: <%= @site.name %></h1>
           </div>
         </div>
-        <div class="bg-white shadow-sm rounded-b-lg overflow-visible">
+        <div class="bg-white shadow-sm rounded-b-lg overflow-x-scroll">
           <div data-controller="bulk-edit" data-bulk-edit-site-id-value="<%= params[:site_id] %>">
             <table class="min-w-full divide-y divide-gray-200 table-zebra">
               <thead class="bg-gray-50">
@@ -47,7 +46,7 @@
                     <input type="checkbox" class="bulk-edit-all" data-bulk-edit-target="selectAll" data-action="click->bulk-edit#handleCheckAll"/>
                   </label>
                 </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-80">
+                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   <%= link_to site_documents_path(@site, sort: 'file_name', direction: (params[:sort] == 'file_name' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
                     File Name
                     <% if params[:sort] == 'file_name' %>
@@ -57,7 +56,7 @@
                     <% end %>
                   <% end %>
                 </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-44">
+                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   <%= link_to site_documents_path(@site, sort: 'modification_date', direction: (params[:sort] == 'modification_date' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
                     Last Modified
                     <% if params[:sort] == 'modification_date' %>
@@ -67,7 +66,7 @@
                     <% end %>
                   <% end %>
                 </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-40">
+                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   <%= link_to site_documents_path(@site, sort: 'document_category', direction: (params[:sort] == 'document_category' && params[:direction] != 'desc') ? 'desc' : 'asc', filename: params[:filename], category: params[:category], start_date: params[:start_date], end_date: params[:end_date], status: params[:status]), class: "group inline-flex items-center" do %>
                     Type
                     <% if params[:sort] == 'document_category' %>
@@ -77,8 +76,8 @@
                     <% end %>
                   <% end %>
                 </th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-44">Decision</th>
-                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-60">Notes</th>
+                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Decision</th>
+                <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notes</th>
               </tr>
               </thead>
               <tbody class="bg-white divide-y divide-gray-200">
@@ -99,15 +98,14 @@
                       <input type="checkbox" class="bulk-edit-document" data-bulk-edit-target="selectOne" data-action="click->bulk-edit#handleCheckOne" data-bulk-edit-document-id-value="<%= document.id %>"/>
                     </label>
                   </td>
-                  <td class="px-3 py-4 text-sm w-80 truncate" title="<%= document.file_name %>" data-controller="modal">
-                    <div class="flex flex-col gap-1">
+                  <td class="px-3 py-4 text-sm" title="<%= document.file_name %>" data-controller="modal">
                       <div class="text-gray-900">
-                        <button data-action="click->modal#openModal">
+                        <button data-action="click->modal#openModal" class="text-left">
                           <i class="fas fa-file-pdf text-sm"></i> <%= document.file_name&.truncate(80) %>
                         </button>
                       </div>
                       <% source = document_source(document.primary_source) %>
-                      <div class="text-gray-400 flex items-center">
+                      <div class="text-gray-400">
                         <%= source[:text] %>
                         <% if source[:url].present? %>
                           <a href="<%= source[:url] %>" target="_blank" rel="noopener noreferrer" class="ml-1 text-primary-600 hover:text-primary-900" title="Open source in new tab">
@@ -115,11 +113,10 @@
                           </a>
                         <% end %>
                       </div>
-                    </div>
                     <%= render partial: "documents/pdf_modal", locals: { document: document } %>
                   </td>
-                  <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500 w-44"><%= document.modification_date&.strftime("%b %d, %Y") %></td>
-                  <td class="px-3 py-4 text-sm w-40" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="document_category">
+                  <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500"><%= document.modification_date&.strftime("%b %d, %Y") %></td>
+                  <td class="px-3 py-4 text-sm" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="document_category">
                     <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer <%= document.document_category.present? ? 'text-primary' : 'text-gray-500' %> flex flex-col gap-1">
                       <div class="hover:underline">
                         <%= document.document_category %>
@@ -137,7 +134,7 @@
                       </div>
                     <% end %>
                   </td>
-                  <td class="px-3 py-4 text-sm text-gray-500 w-44 truncate" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="accessibility_recommendation">
+                  <td class="px-3 py-4 text-sm text-gray-500" data-controller="dropdown-edit" data-dropdown-edit-document-id-value="<%= document.id %>" data-dropdown-edit-field-value="accessibility_recommendation">
                     <div data-action="click->dropdown-edit#showSelect" data-dropdown-edit-target="display" class="cursor-pointer text-primary flex flex-col gap-1">
                       <%= document.accessibility_recommendation.present? ? document.accessibility_recommendation : Document::DEFAULT_ACCESSIBILITY_RECOMMENDATION.to_s %>
                     </div>
@@ -147,12 +144,12 @@
                       <% end %>
                     </select>
                     <% if document.accessibility_recommendation_from_inferences.present? %>
-                      <div class="text-xs text-gray-500 flex items-center gap-1">
+                      <div class="text-xs text-gray-500 flex items-center gap-1 truncate">
                         <i class="fas fa-wand-magic-sparkles leave-icon"></i><%= document.accessibility_recommendation_from_inferences %>
                       </div>
                     <% end %>
                   </td>
-                  <td class="px-3 py-4 text-sm text-gray-500 w-60" data-controller="text-edit" data-text-edit-document-id-value="<%= document.id %>" data-text-edit-field-value="notes">
+                  <td class="px-3 py-4 text-sm text-gray-500" data-controller="text-edit" data-text-edit-document-id-value="<%= document.id %>" data-text-edit-field-value="notes">
                     <div data-text-edit-target="display" data-action="click->text-edit#showTextarea" class="cursor-pointer hover:underline min-w-40">
                       <%= document.notes.present? ? document.notes : "No notes" %>
                     </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -163,8 +163,8 @@
               <% end %>
               </tbody>
             </table>
-            <div id="bulk_edit_control" class="w-fit fixed bottom-0 left-0 right-0 ml-auto mr-auto hidden" data-bulk-edit-target="actions">
-              <div class="join py-4 bg-white border border-gray-300 border-b-0 shadow-md rounded-b-none">
+            <div id="bulk_edit_control" class="w-fit fixed left-0 right-0 ml-auto mr-auto animate-up off-screen-bottom" data-bulk-edit-target="actions">
+              <div class="join py-4 bg-white border-2 border-gray-300 border-b-0 shadow-md rounded-b-none">
                 <div class="checked-count join-item px-4 border-r border-gray-300 py-1">Selected: <span>1</span>
                 </div>
                 <div class="join-item px-4 border-r border-gray-300">

--- a/app/views/sites/insights.html.erb
+++ b/app/views/sites/insights.html.erb
@@ -2,9 +2,9 @@
   <%= tag.meta name: "site-id", content: @site.id %>
 <% end %>
 <div class="py-6">
-  <div class="mx-auto sm:px-6 lg:px-8">
-    <div class="grid grid-cols-[250px_1fr] gap-6">
-      <div id="sidebar" class="space-y-6">
+  <div class="mx-auto px-6 lg:px-8">
+    <div class="grid grid-cols-1 lg:grid-cols-[250px_1fr] lg:gap-6">
+      <div id="sidebar" class="space-y-6 mb-6">
         <%= render partial: "shared/site_navigation", locals: { site: @site } %>
         <div class="bg-white shadow-sm rounded-lg h-fit">
           <div class="border-b">
@@ -36,7 +36,7 @@
               </label>
               <%= select_tag :status,
                              options_for_select({ 'All Statuses': '' }.merge(Document::get_status_options), params[:status]),
-                             class: "select-custom w-full" + (params[:status].present? ? " active-highlight" : "")  %>
+                             class: "select-custom w-full" + (params[:status].present? ? " active-highlight" : "") %>
             </div>
             <div class="flex justify-end pt-4">
               <div>
@@ -47,7 +47,7 @@
           <% end %>
         </div>
       </div>
-      <div id="insights" class="px-4 sm:px-0 space-y-0">
+      <div id="insights" class="space-y-0">
         <div class="bg-gray-50 shadow-sm rounded-t-lg px-6 py-4  border-b-gray-200 border-b">
           <div class="flex justify-between items-center">
             <h1 class="text-lg font-medium"><%= @site.location %>: <%= @site.name %></h1>
@@ -62,30 +62,35 @@
           </div>
         </div>
         <div class="bg-white shadow-sm border-b overflow-visible">
-          <div class="grid grid-cols-3 gap-6 py-4">
-            <div id="chart-complexity" class="px-4 border-r-4 border-base-200">
-              <h2 class="pb-4">Document Complexity</h2>
-              <%= pie_chart @documents.group(:complexity).count, colors: ["#ea3c48", "#f5a6ac"] %>
-              <div class="dropdown dropdown-start pt-6">
-                <div tabindex="0" role="button" class="btn btn-sm "><i class="fas fa-link w-5"></i>View Documents</div>
-                <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm">
-                  <% @document_links[:complexity].each do | item | %>
-                    <li>
-                      <%= link_to site_documents_path(@site, **item[:params]) do %>
-                        <%= item[:title] %>
-                      <% end %>
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
+          <div class="grid grid-cols-1 lg:grid-cols-3 lg:gap-6 py-4">
+            <div id="chart-complexity" class="px-4 mb-12 lg:border-r-4 border-base-200 min-h-30">
+              <h2 class="pb-4 text-xl font-semibold">Document Complexity</h2>
+              <% if @site.has_complexities? %>
+                <%= pie_chart @documents.group(:complexity).count, colors: ["#ea3c48", "#f5a6ac"] %>
+                <div class="dropdown dropdown-start pt-6">
+                  <div tabindex="0" role="button" class="btn btn-sm "><i class="fas fa-link w-5"></i>View Documents
+                  </div>
+                  <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm">
+                    <% @document_links[:complexity].each do |item| %>
+                      <li>
+                        <%= link_to site_documents_path(@site, **item[:params]) do %>
+                          <%= item[:title] %>
+                        <% end %>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
+              <% else %>
+                <p>No document complexity data available.</p>
+              <% end %>
             </div>
-            <div id="chart-modification-year" class="px-4">
-              <h2 class="pb-4">Document Last Modified Year</h2>
+            <div id="chart-modification-year" class="px-4 mb-12 ">
+              <h2 class="pb-4 text-xl font-semibold">Document Last Modified Year</h2>
               <%= bar_chart @document_years, library: { scales: { y: { ticks: { autoSkip: false } } } }, colors: ["#ea3c48"] %>
               <div class="dropdown dropdown-start pt-6">
                 <div tabindex="0" role="button" class="btn btn-sm "><i class="fas fa-link w-5"></i>View Documents</div>
                 <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-1 w-96 p-2 shadow-sm max-h-40">
-                  <% @document_links[:years].each do | item | %>
+                  <% @document_links[:years].each do |item| %>
                     <li>
                       <%= link_to site_documents_path(@site, **item[:params]) do %>
                         <%= item[:title] %>
@@ -95,13 +100,13 @@
                 </ul>
               </div>
             </div>
-            <div id="chart-decision" class="px-4 border-l-4 border-base-200">
-              <h2 class="pb-4">Decision</h2>
+            <div id="chart-decision" class="px-4 mb-12  lg:border-l-4 border-base-200">
+              <h2 class="pb-4 text-xl font-semibold">Decision</h2>
               <%= column_chart @documents.group(:accessibility_recommendation).count, colors: ["#ea3c48", "#f5a6ac"] %>
               <div class="dropdown dropdown-start pt-6">
                 <div tabindex="0" role="button" class="btn btn-sm "><i class="fas fa-link w-5"></i>View Documents</div>
                 <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-1 w-96 p-2 shadow-sm max-h-40">
-                  <% @document_links[:decision].each do | item | %>
+                  <% @document_links[:decision].each do |item| %>
                     <li>
                       <%= link_to site_documents_path(@site, **item[:params]) do %>
                         <%= item[:title] %>
@@ -113,27 +118,27 @@
             </div>
           </div>
         </div>
-        <div class="bg-white shadow-sm rounded-b-lg overflow-visible px-6 py-4">
-          <h2 class="pb-4">Documents by Type</h2>
+        <div class="bg-white shadow-sm rounded-b-lg overflow-visible px-6 py-4 overflow-x-scroll">
+          <h2 class="pb-4 text-xl font-semibold">Documents by Type</h2>
           <table class="min-w-full divide-y divide-gray-200 table-zebra">
             <thead class="bg-gray-50">
             <tr>
               <th scope="col" class="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-              <th scope="col" class="px-3 py-3 text-center  text-xs font-medium text-gray-500 uppercase tracking-wider"><%=Document::DEFAULT_STATUS %></th>
-              <th scope="col" class="px-3 py-3 text-center  text-xs font-medium text-gray-500 uppercase tracking-wider"><%= Document::IN_REVIEW_STATUS %></th>
-              <th scope="col" class="px-3 py-3 text-center  text-xs font-medium text-gray-500 uppercase tracking-wider"><%= Document::DONE_STATUS %></th>
+              <th scope="col" class="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"><%= Document::DEFAULT_STATUS %></th>
+              <th scope="col" class="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"><%= Document::IN_REVIEW_STATUS %></th>
+              <th scope="col" class="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"><%= Document::DONE_STATUS %></th>
               <th scope="col" class="px-3 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
             </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
             <% @category_groups.each do |category, counts| %>
-            <tr>
-              <td class="px-3 py-3 text-base font-medium text-gray-500"><%= category %></td>
-              <td class="px-3 py-3 text-base text-center  font-medium text-gray-500"><%= counts["Audit Backlog"] %></td>
-              <td class="px-3 py-3 text-base text-center font-medium text-gray-500"><%= counts["In Review"] %></td>
-              <td class="px-3 py-3 text-base text-center font-medium text-gray-500"><%= counts["Audit Done"] %></td>
-              <td class="px-3 py-3 text-base text-center font-medium text-gray-500"><%= counts["Total"] %></td>
-            </tr>
+              <tr>
+                <td class="px-3 py-3 text-base font-medium text-gray-500"><%= category %></td>
+                <td class="px-3 py-3 text-base text-center  font-medium text-gray-500"><%= counts["Audit Backlog"] %></td>
+                <td class="px-3 py-3 text-base text-center font-medium text-gray-500"><%= counts["In Review"] %></td>
+                <td class="px-3 py-3 text-base text-center font-medium text-gray-500"><%= counts["Audit Done"] %></td>
+                <td class="px-3 py-3 text-base text-center font-medium text-gray-500"><%= counts["Total"] %></td>
+              </tr>
             <% end %>
             </tbody>
           </table>

--- a/spec/features/document_spec.rb
+++ b/spec/features/document_spec.rb
@@ -301,7 +301,7 @@ describe "documents function as expected", js: true, type: :feature do
       expect(page).to have_content "rtd_contract.pdf\nAgreement\n73%\nNeeds Decision"
       expect(page).to have_content "teahouse_rules.pdf\nNotice\n71%\nNeeds Decision"
       expect(page).to have_content "farmers_market_2023.pdf\nOct 01, 2024\nNotice\nNeeds Decision"
-      expect(page).to have_no_css("#bulk_edit_control", visible: true)
+      expect(page).to have_css("#bulk_edit_control.off-screen-bottom", visible: false)
       # Try checking a box.
       find("tr:nth-child(1) [data-bulk-edit-target='selectOne']").check
     end
@@ -309,8 +309,8 @@ describe "documents function as expected", js: true, type: :feature do
       expect(page).to have_content "Selected: 1"
       # Try clicking the "x".
       find("[data-action='bulk-edit#handleCloseActions']").click
-      expect(page).to have_no_css("#bulk_edit_control", visible: true)
     end
+    expect(page).to have_css("#bulk_edit_control.off-screen-bottom", visible: false)
     within("#document-list") do
       checkbox = find("tr:nth-child(1) [data-bulk-edit-target='selectOne']")
       expect(checkbox).not_to be_checked
@@ -327,7 +327,7 @@ describe "documents function as expected", js: true, type: :feature do
       expect(page).to have_content 'You are about to move 3 documents to "In Review".'
       click_button "Cancel"
     end
-    expect(page).to have_no_selector("#bulk_edit_modal", visible: true)
+    expect(page).to have_no_selector("#bulk_edit_modal.off-screen-bottom")
     within("#bulk_edit_control") do
       select = find("#bulk-edit-move")
       select.find("[value='In Review']").click


### PR DESCRIPTION
When we reworked the document table widths a few weeks ago, we created some scenarios where long document titles (which our stakeholders have) cause the table to explode from its container at a relatively large screen size. The app is not terribly mobile friendly. We probably don't intend it to be a mobile-first experience. However, it should be able to hold up a little bit better than it does. Let's do some very lightweight theming to try and improve the app on all screen sizes.

**Before screenshot:**

![Screenshot 2025-05-13 at 9 05 35 AM](https://github.com/user-attachments/assets/46fab542-8c03-4842-84ed-2e874466d744)

Filenames and keywords are forced to stay on one line, creating an inflexible layout.

**After screenshot**
![Screenshot 2025-05-13 at 9 11 27 AM](https://github.com/user-attachments/assets/8905bc4f-bbaf-4126-84b0-c995007a87ef)

Filenames and keywords are liquid wrapping to multiple lines.

**Smaller screens**
![Screenshot 2025-05-13 at 9 09 08 AM](https://github.com/user-attachments/assets/417d884a-16c6-4488-8f45-f5f00f979c05)

![Screenshot 2025-05-13 at 9 09 19 AM](https://github.com/user-attachments/assets/f303531f-10c9-444b-9ad0-0d03b505a3a6)

This PR adds:
* Better responsive theming for the documents and insights page.
* An animation and thicker stroke for the bulk-edit toolbar.
