### PR TITLE
Asap 161 fix url edgecases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+- What additional steps are required to test this branch locally?
+- Are there any areas you would like extra review?
+- Are there any rake tasks to run on production?

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -40,7 +40,9 @@ class DocumentsController < AuthenticatedController
   end
 
   def serve_document_url
-    response = HTTParty.get(@document.url)
+    # Stash document's raw url.
+    document_url = normalize_url(@document.url)
+    response = HTTParty.get(document_url)
     if response.success?
       send_data response.body,
         type: "application/pdf",
@@ -144,6 +146,20 @@ class DocumentsController < AuthenticatedController
   end
 
   private
+
+  def normalize_url(url)
+    decoded_url = self.recursive_decode(url)
+    decoded_url = decoded_url.gsub('\\', '/')
+    URI::DEFAULT_PARSER.escape(decoded_url)
+  end
+
+  def recursive_decode(url)
+    decoded_url = URI::DEFAULT_PARSER.unescape(url)
+    if url != decoded_url
+      decoded_url = self.recursive_decode(decoded_url)
+    end
+    decoded_url
+  end
 
   def batch_params
     params.permit(:site_id, document: {}, documents: [:id, :status]).to_h

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -29,7 +29,7 @@ class DocumentsController < AuthenticatedController
 
   def serve_document_url
     # Stash document's raw url.
-    document_url = normalize_url(@document.url)
+    document_url = @document.normalized_url
     response = HTTParty.get(document_url)
     if response.success?
       send_data response.body,
@@ -134,20 +134,6 @@ class DocumentsController < AuthenticatedController
   end
 
   private
-
-  def normalize_url(url)
-    decoded_url = self.recursive_decode(url)
-    decoded_url = decoded_url.gsub('\\', '/')
-    URI::DEFAULT_PARSER.escape(decoded_url)
-  end
-
-  def recursive_decode(url)
-    decoded_url = URI::DEFAULT_PARSER.unescape(url)
-    if url != decoded_url
-      decoded_url = self.recursive_decode(decoded_url)
-    end
-    decoded_url
-  end
 
   def batch_params
     params.permit(:site_id, document: {}, documents: [:id, :status]).to_h

--- a/app/helpers/url_decoded_attribute_helper.rb
+++ b/app/helpers/url_decoded_attribute_helper.rb
@@ -1,8 +1,0 @@
-module UrlDecodedAttributeHelper
-  def url_decoded_attribute(attribute)
-    define_method(attribute) do
-      return nil if self[attribute].nil?
-      URI::DEFAULT_PARSER.unescape(self[attribute])
-    end
-  end
-end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,14 +1,10 @@
 class Document < ApplicationRecord
-  extend UrlDecodedAttributeHelper
 
   belongs_to :site
   has_many :workflow_histories, class_name: "DocumentWorkflowHistory"
   has_many :document_inferences
 
   has_paper_trail versions: {scope: -> { order(created_at: :desc) }}
-
-  url_decoded_attribute :file_name
-  url_decoded_attribute :url
 
   scope :by_filename, ->(filename) {
     return all if filename.blank?
@@ -128,10 +124,14 @@ class Document < ApplicationRecord
     end
   end
 
-  alias_method :decoded_url, :url
+  def file_name
+    unescaped_file_name = URI::DEFAULT_PARSER.unescape(self[:file_name])
+    unescaped_file_name.gsub('?', '')
+                       .gsub('/', '')
+  end
 
   def url
-    decoded_url&.sub("http://", "https://")
+    self[:url]&.sub("http://", "https://")
   end
 
   def s3_path

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,4 @@
 class Document < ApplicationRecord
-
   belongs_to :site
   has_many :workflow_histories, class_name: "DocumentWorkflowHistory"
   has_many :document_inferences
@@ -150,18 +149,18 @@ class Document < ApplicationRecord
     # If we have a value make unescape before displaying.
     unescaped_file_name = URI::DEFAULT_PARSER.unescape(self[:file_name])
     # Filenames, cannot have characters with special url-meaning.
-    unescaped_file_name.gsub('?', '')
-                       .gsub('/', '')
+    unescaped_file_name.delete("?")
+      .delete("/")
   end
 
   def url
     self[:url]&.sub("http://", "https://")
   end
 
-  def normalized_url()
-    decoded_url = self.recursive_decode(self.url)
+  def normalized_url
+    decoded_url = recursive_decode(url)
     # Add any additional oddities here.
-    decoded_url = decoded_url.gsub('\\', '/')
+    decoded_url = decoded_url.tr("\\", "/")
     URI::DEFAULT_PARSER.escape(decoded_url)
   end
 
@@ -310,7 +309,7 @@ class Document < ApplicationRecord
   def recursive_decode(url)
     decoded_url = URI::DEFAULT_PARSER.unescape(url)
     if url != decoded_url
-      decoded_url = self.recursive_decode(decoded_url)
+      decoded_url = recursive_decode(decoded_url)
     end
     decoded_url
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -162,7 +162,6 @@ class Site < ApplicationRecord
         skipped = 0
         chunk.each do |row|
           row = row.stringify_keys
-          encoded_url = URI::DEFAULT_PARSER.escape(row["url"])
 
           # Parse file size (remove KB suffix and convert to float)
           file_size = row["file_size"]&.gsub("KB", "")&.strip&.to_f
@@ -175,7 +174,7 @@ class Site < ApplicationRecord
           end
 
           documents << {
-            url: encoded_url,
+            url: row["url"],
             file_name: row["file_name"],
             file_size: file_size,
             author: row["author"],

--- a/app/views/documents/_modal_content.html.erb
+++ b/app/views/documents/_modal_content.html.erb
@@ -35,7 +35,7 @@
           </button>
         <% end %>
       </div>
-      <iframe src="<%= serve_file_content_document_path(@document.id,  @document.file_name) %>?pagemode=none&toolbar=1" class="w-full h-[calc(90vh-8rem)]" type="application/pdf"></iframe>
+      <iframe src="<%= serve_file_content_document_path(@document.id, @document.file_name) %>?pagemode=none&toolbar=1" class="w-full h-[calc(90vh-8rem)]" type="application/pdf"></iframe>
     </div>
     <!-- PDF Details View -->
     <div data-modal-target="metadataView" class="hidden h-[calc(90vh-12rem)] overflow-y-auto bg-white rounded-md">


### PR DESCRIPTION
Our current url encoding strategy is as follows:

1. Encode documents before saving.
2. Decode documents when url getter is called.

Currently, we are fetch PDF content for via decoded urls. This works in most cases, but there are some documents with decoded urls that break the display process (identified by SLC). To make matters more complicated some documents were retrieved with escape sequences already present. We need to encode urls before requesting PDF content, but we need to make sure we don't double encode, which also breaks our display.

Our new url encoding strategy is as follows:
1. Import raw urls, but support previously imported encoded urls.
2. Decode recursively until they may no longer be decoded.
3. Encode and request.

This PR adds the following:
* Splits the url getter method into a raw and normalized versions
* Removes the url encoding helper, which was no longer needed
* Adds support for filenames with special (url-related) characters
* Removes url encoding from import process
* Adds and updates tests.