### PR TITLE
1337 model update 2025 05 15

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -214,7 +214,7 @@ class Document < ApplicationRecord
       end
       payload = {
         model_name: "gemini-1.5-pro-latest",
-        documents: [{id: id, title: file_name, url: url, purpose: document_category}],
+        documents: [{id: id, title: file_name, url: normalized_url, purpose: document_category}],
         page_limit: 7,
         inference_type: "summary",
         asap_endpoint: "#{api_host}/api/documents/#{id}/inference"
@@ -246,8 +246,8 @@ class Document < ApplicationRecord
         api_host = "https://demo.codeforamerica.ai"
       end
       payload = {
-        model_name: "gemini-2.0-pro-exp-02-05",
-        documents: [{id: id, title: file_name, url: url, purpose: document_category}],
+        model_name: "gemini-2.5-pro-preview-03-25",
+        documents: [{id: id, title: file_name, url: normalized_url, purpose: document_category}],
         page_limit: 7,
         inference_type: "exception",
         asap_endpoint: "#{api_host}/api/documents/#{id}/inference"

--- a/app/views/layouts/centered.html.erb
+++ b/app/views/layouts/centered.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Access Pdf Ui" %></title>
+    <title><%= content_for(:title) || "PDF Audit Tool - Code for America" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/python_components/document_inference/models.json
+++ b/python_components/document_inference/models.json
@@ -5,7 +5,7 @@
   "gemini-1.5-pro-latest": {
     "key": "asap-pdf/production/GOOGLE_AI_KEY"
   },
-  "gemini-2.0-pro-exp-02-05": {
+  "gemini-2.5-pro-preview-03-25": {
     "key": "asap-pdf/production/GOOGLE_AI_KEY"
   }
 }

--- a/python_components/document_inference/requirements.txt
+++ b/python_components/document_inference/requirements.txt
@@ -9,7 +9,7 @@ inflect==7.3.1
 isort==6.0.1
 jaraco.collections==5.1.0
 llm-anthropic==0.15.1
-llm-gemini==0.16
+llm-gemini==0.19.1
 pillow==11.2.1
 pip-chill==1.0.3
 pymupdf==1.25.5


### PR DESCRIPTION
It seems like Google either severely rate limits experimental models or completely discontinued the one we were using. We need to switch to an equivalent, supported model.

This PR adds the following:
* Changes our document inference code to use  gemini-2.5-pro-preview-03-25 instead of gemini-2.0-pro-exp-02-05.
* Removes gemini-2.0-pro-exp-02-05 from model options
* **Unrelated:** Use the normalized_url to make AI requests. I notice some SLC urls that were not working correctly and this fixed it.
* **Unrelated:** Fix the title on the login page.