### PR TITLE
Fix corrupted SLC urls

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -177,7 +177,7 @@ class Document < ApplicationRecord
   def normalized_url
     decoded_url = recursive_decode(url)
     # Add any additional oddities here.
-    decoded_url = decoded_url.tr("\\", "/")
+    decoded_url = decoded_url.tr("\\", "/").tr("+", " ")
     URI::DEFAULT_PARSER.escape(decoded_url)
   end
 

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -67,8 +67,7 @@ namespace :documents do
       "salt_lake_city.csv" => slc
     }
 
-    # archive_name = (Rails.env != "production") ? "site_documents_dev.zip" : "site_documents.zip"
-    archive_name = "site_documents.zip"
+    archive_name = (Rails.env != "production") ? "site_documents_dev.zip" : "site_documents.zip"
     puts "Loading site data from #{archive_name}"
 
     Zip::File.open(Rails.root.join("db", "seeds", archive_name)) do |zipfile|
@@ -170,20 +169,5 @@ namespace :documents do
         document.save
       end
     end
-  end
-
-  desc "Normalize bad URLs"
-  task :normalize_bad_urls, [:site_id] => :environment do |t, args|
-    site = Site.find(args.site_id)
-    p "Normalizing bad URLS for site #{site.name}..."
-    update_count = 0
-    PaperTrail.request(enabled: false) do
-      site.documents.where("url like '%+%'").find_each(batch_size: 50) do |document|
-        document.url = document.normalized_url
-        document.save!
-        update_count += 1
-      end
-    end
-    p "Updated #{update_count} documents."
   end
 end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -67,7 +67,8 @@ namespace :documents do
       "salt_lake_city.csv" => slc
     }
 
-    archive_name = (Rails.env != "production") ? "site_documents_dev.zip" : "site_documents.zip"
+    # archive_name = (Rails.env != "production") ? "site_documents_dev.zip" : "site_documents.zip"
+    archive_name = "site_documents.zip"
     puts "Loading site data from #{archive_name}"
 
     Zip::File.open(Rails.root.join("db", "seeds", archive_name)) do |zipfile|
@@ -169,5 +170,20 @@ namespace :documents do
         document.save
       end
     end
+  end
+
+  desc "Normalize bad URLs"
+  task :normalize_bad_urls, [:site_id] => :environment do |t, args|
+    site = Site.find(args.site_id)
+    p "Normalizing bad URLS for site #{site.name}..."
+    update_count = 0
+    PaperTrail.request(enabled: false) do
+      site.documents.where("url like '%+%'").find_each(batch_size: 50) do |document|
+        document.url = document.normalized_url
+        document.save!
+        update_count += 1
+      end
+    end
+    p "Updated #{update_count} documents."
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Document, type: :model do
       expect(document.normalized_url).to eq("https://www.slcdocs.com/building/January%20Report%202025.pdf")
       document.url = "https://www.slcdocs.com%5Crecorder%5CEO_Disclosures%5CD4_Eva_Lopez_Chavez_2025Dislosure.pdf"
       expect(document.normalized_url).to eq("https://www.slcdocs.com/recorder/EO_Disclosures/D4_Eva_Lopez_Chavez_2025Dislosure.pdf")
+      document.url = "https://www.slcdocs.com/Planning/Online+Open+Houses/2023/07_2023/PLNPCM2023-00482/SIDWELL+PARCEL+MAP+%282%29.pdf"
+      expect(document.normalized_url).to eq("https://www.slcdocs.com/Planning/Online%20Open%20Houses/2023/07_2023/PLNPCM2023-00482/SIDWELL%20PARCEL%20MAP%20(2).pdf")
     end
     it "converts insecure urls to https" do
       document.url = "http://www.austintexas.gov/growgreen/%25C3%2581fidos_GrowGreen_web.pdf"


### PR DESCRIPTION
We went through several attempts to normalize and properly encode document urls. At one point in the past, we were using Ruby's `CGI.escape` method to sanitize URLs before storage. We then called `CGI.unescape` on retrieval before fetching the PDF. This worked in many cases, but broke some URLs that were already encoded in the csv site data. We moved away from the CGI based approach, but some URLs were still encoded with plus symbols.

CGI.escape documentation:

>URL-encode a string into application/x-www-form-urlencoded. Space characters (+" "+) are encoded with plus signs (+"+"+) url_encoded_string = CGI.escape("'Stop # => "%27Stop%21%27+said+Fred" 

This doesn't seem to cause problems for some stakeholder URLs. However, some SLC documents are broken. Here is an example:

Stored value:

```
https://www.slcdocs.com/Planning/Online+Open+Houses/2023/07_2023/PLNPCM2023-00482/SIDWELL+PARCEL+MAP+(2).pdf 
```

Good/Initial value:

```
http://www.slcdocs.com/Planning/Online Open Houses/2023/07_2023/PLNPCM2023-00482/SIDWELL PARCEL MAP (2).pdf
```

Overall, I think this impacts about 2500 SLC documents in production:

```
(AWS) access_pdf_production=> select count(1), site_id from documents where url like '%+%' group by site_id;
 count | site_id 
-------+---------
  2464 |       1
     2 |       3
(2 rows)
 ```

This PR replaces "+" symbols with spaces " " and adds a test for the SLC URL featured above. I tested some other URLs with + symbols and they all seem to work with " " instead. This includes the two documents from Austin in the query above. This small fix should repair the URLs as they are rendered. I also included a rake task to fix the urls in the database. This may be helpful if we export the database for SLC in the future.

- **What additional steps are required to test this branch locally?**
None

- **Are there any rake tasks to run on production?**

Yes, here it is: 

```
bin/rake documents:normalize_bad_urls[1]
```
