### PR TITLE
Add author to history tab.

### DIFF
--- a/app/views/documents/_modal_content.html.erb
+++ b/app/views/documents/_modal_content.html.erb
@@ -177,6 +177,15 @@
                 </div>
                 <div class="text-sm text-gray-500">
                   <%= version.created_at.strftime("%B %d, %Y %I:%M %p") %>
+                  <br>
+                  <% if version.whodunnit.present? %>
+                  <% user=User.find(version.whodunnit) %>
+                    <% if user.present? %>
+                      Author: <%= user.email_address %>
+                    <% end %>
+                  <% else %>
+                    Author: System
+                  <% end %>
                 </div>
               </div>
               <div class="mt-3 space-y-2">


### PR DESCRIPTION
We want to show the author of revisions in the history tab. Right now we only collect the user's email address. We can show that for now and then change it if we collect username in the future.

This PR updates the history tab to show the author of a version. If the author was the system, the change is reported to have been created by "system". 

- What additional steps are required to test this branch locally?

None.

- Are there any areas you would like extra review?

Make some changes to a document and look the history tab.


- Are there any rake tasks to run on production?

No