### PR TITLE
Add tooltip to filters and insights page.

### DIFF
--- a/app/views/shared/_filter.html.erb
+++ b/app/views/shared/_filter.html.erb
@@ -17,7 +17,7 @@
           </div>
           <div class="space-y-2">
             <%= date_field_tag :start_date, params[:start_date], class: "input input-bordered w-full" + (params[:start_date].present? ? " active-highlight" : ""), placeholder: "From", "aria-labelledby": "date-filter-label" %>
-            <%= date_field_tag :end_date, params[:end_date], class: "input input-bordered w-full"+ (params[:end_date].present? ? " active-highlight" : ""), placeholder: "To", "aria-labelledby": "date-filter-label" %>
+            <%= date_field_tag :end_date, params[:end_date], class: "input input-bordered w-full" + (params[:end_date].present? ? " active-highlight" : ""), placeholder: "To", "aria-labelledby": "date-filter-label" %>
           </div>
         </div>
         <div>
@@ -40,14 +40,17 @@
               <span class="label-text">Department</span>
             </label>
             <%= select_tag :department,
-                           options_for_select({'All Departments': ''}.merge(site.get_departments), params[:department]),
+                           options_for_select({ 'All Departments': '' }.merge(site.get_departments), params[:department]),
                            class: "select-custom w-full" + (params[:department].present? ? " active-highlight" : "") %>
           </div>
         <% end %>
         <% if site.has_complexities? %>
           <div>
             <label for="complexity" class="label">
-              <span class="label-text">Complexity</span>
+              <%
+                tooltip_text = '"Simple" filters by easier-to-review documents that have no images or tables, and likely aren\'t forms.'
+              %>
+              <span class="label-text">Complexity <span class="tooltip tooltip-right tooltip-primary" data-tip="<%= tooltip_text %>"><i class="fas fa-question-circle w-5"></i></span></span>
             </label>
             <%= select_tag :complexity,
                            options_for_select([['All Documents', '']] + Document::get_complexity_options, params[:complexity]),

--- a/app/views/sites/insights.html.erb
+++ b/app/views/sites/insights.html.erb
@@ -57,7 +57,7 @@
           <div class="grid grid-cols-1 lg:grid-cols-3 lg:gap-6 py-4">
             <div id="chart-complexity" class="px-4 mb-12 lg:border-r-4 border-base-200 min-h-30">
               <%
-                tooltip_text = '"Simple" documents are easier-to-review. They have no images or tables, and likely aren\'t forms.'
+                tooltip_text = '"Simple" documents are easier to review. They have no images or tables, and likely aren\'t forms.'
               %>
               <h2 class="pb-4 text-xl font-semibold">Document Complexity
                 <span class="tooltip tooltip-right tooltip-primary text-sm" data-tip="<%= tooltip_text %>"><i class="fas fa-question-circle w-5"></i></span>

--- a/app/views/sites/insights.html.erb
+++ b/app/views/sites/insights.html.erb
@@ -56,7 +56,12 @@
         <div class="bg-white shadow-sm border-b overflow-visible">
           <div class="grid grid-cols-1 lg:grid-cols-3 lg:gap-6 py-4">
             <div id="chart-complexity" class="px-4 mb-12 lg:border-r-4 border-base-200 min-h-30">
-              <h2 class="pb-4 text-xl font-semibold">Document Complexity</h2>
+              <%
+                tooltip_text = '"Simple" documents are easier-to-review. They have no images or tables, and likely aren\'t forms.'
+              %>
+              <h2 class="pb-4 text-xl font-semibold">Document Complexity
+                <span class="tooltip tooltip-right tooltip-primary text-sm" data-tip="<%= tooltip_text %>"><i class="fas fa-question-circle w-5"></i></span>
+              </h2>
               <% if @site.has_complexities? %>
                 <%= pie_chart @documents.group(:complexity).count, colors: ["#ea3c48", "#f5a6ac"] %>
                 <div class="dropdown dropdown-start pt-6">


### PR DESCRIPTION
We'd like to add some explanation of our document complexity data point.  We think a tooltip near the filter and on the insights page would make sense.

This PR adds said tooltips.

### Bean Footage

**Filter:**
<br/><br/>
<img width="240" height="107" alt="Screenshot 2025-07-18 at 1 18 43 PM" src="https://github.com/user-attachments/assets/09217f06-6c60-4bc2-a4a4-1ba5d9e5f923" />
<br/>
<img width="476" height="297" alt="Screenshot 2025-07-18 at 2 39 36 PM" src="https://github.com/user-attachments/assets/11f612af-1484-4c1c-87b5-2a64f1a0d142" />
<br/>
<br/>
**Insights page:**
<br/>
<br/>
<img width="673" height="455" alt="Screenshot 2025-07-18 at 1 25 10 PM" src="https://github.com/user-attachments/assets/e12133aa-7a1f-4642-a7dd-baa0600341ec" />
<br/>
<img width="675" height="512" alt="Screenshot 2025-07-18 at 1 25 15 PM" src="https://github.com/user-attachments/assets/14de649e-2288-4709-99ae-a893e0c48b9d" />
<br/>

- **What additional steps are required to test this branch locally?**

None

- **Are there any areas you would like extra review?**

Welcome feedback on the copy.

- **Are there any rake tasks to run on production?**

No
