### PR TITLE
Add cloudfront module with temporary redirect for production domain.

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < Devise::Mailer
-  default from: "Code for America <admin@demo.codeforamerica.ai>"
+  default from: "Code for America <admin@ada.codeforamerica.ai>"
 
   layout "mailer"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,14 +31,14 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: ENV.fetch("SMTP_ENDPOINT", ""),
     port: 587,
-    domain: "demo.codeforamerica.ai",
+    domain: "ada.codeforamerica.ai",
     user_name: ENV.fetch("SMTP_USER", ""),
     password: ENV.fetch("SMTP_PASSWORD", ""),
     authentication: "plain"
   }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = {host: "demo.codeforamerica.ai"}
+  config.action_mailer.default_url_options = {host: "ada.codeforamerica.ai"}
 
   config.i18n.fallbacks = true
   config.active_record.dump_schema_after_migration = false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,4 @@ if Rails.env.development?
   Rake::Task["users:create_admin"].invoke("password")
   Rake::Task["documents:bootstrap"].invoke
   Rake::Task["documents:update_department"].invoke("1")
-  Rake::Task["documents:add_pdf_complexity"].invoke
 end

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,6 +15,15 @@ module "backend" {
   environment = var.environment
 }
 
+module "cloudfront" {
+  source = "./modules/cloudfront"
+
+  destination = "https://${var.domain_name}"
+  source_domain = var.redirect_domain
+  logging_bucket = module.logging.bucket
+}
+
+
 module "secrets" {
   source = "github.com/codeforamerica/tofu-modules-aws-secrets?ref=1.0.0"
 

--- a/terraform/modules/cloudfront/data.tf
+++ b/terraform/modules/cloudfront/data.tf
@@ -1,0 +1,9 @@
+data "aws_route53_zone" "source" {
+  for_each = var.create_records ? toset(["this"]) : toset([])
+
+  name = var.source_domain
+}
+
+data "aws_cloudfront_cache_policy" "endpoint" {
+  name = "Managed-CachingOptimized"
+}

--- a/terraform/modules/cloudfront/local.tf
+++ b/terraform/modules/cloudfront/local.tf
@@ -1,0 +1,4 @@
+locals {
+  fqdn = join(".", compact([var.source_subdomain, var.source_domain]))
+  name = "redirect-${replace(local.fqdn, ".", "-")}"
+}

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -1,0 +1,127 @@
+resource "aws_cloudfront_function" "this" {
+  name    = local.name
+  runtime = "cloudfront-js-2.0"
+  comment = "Redirect ${local.fqdn} to ${var.destination}."
+  publish = true
+  code = templatefile("${path.module}/templates/function.js.tftpl", {
+    destination = var.destination
+    static      = var.static
+    status_code = var.status_code
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# TODO: Use a WAF?
+#trivy:ignore:AVD-AWS-0011
+resource "aws_cloudfront_distribution" "this" {
+  enabled         = true
+  comment         = "Redirect ${local.fqdn} to ${var.destination}."
+  is_ipv6_enabled = true
+  aliases         = [var.source_domain]
+  price_class     = "PriceClass_100"
+
+  origin {
+    domain_name         = var.source_domain
+    origin_id           = "redirect"
+    connection_attempts = 1
+    connection_timeout  = 1
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = "${var.logging_bucket}.s3.amazonaws.com"
+    prefix          = "cloudfront/${local.fqdn}"
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "redirect"
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 0
+    compress               = false
+    cache_policy_id        = data.aws_cloudfront_cache_policy.endpoint.id
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.this.arn
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.this.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_acm_certificate" "this" {
+  domain_name       = var.source_domain
+  validation_method = "DNS"
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "this" {
+  for_each = var.create_records ? toset(["A", "AAAA"]) : toset([])
+
+  zone_id = data.aws_route53_zone.source["this"].zone_id
+  name    = local.fqdn
+  type    = each.value
+
+  alias {
+    # CloudFront doesn't provide a health check.
+    evaluate_target_health = false
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+  }
+}
+
+resource "aws_route53_record" "validation" {
+  for_each = var.create_records ? {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name    = dvo.resource_record_name
+      record  = dvo.resource_record_value
+      type    = dvo.resource_record_type
+      zone_id = data.aws_route53_zone.source["this"].zone_id
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = each.value.zone_id
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  for_each = var.create_records ? toset(["this"]) : toset([])
+
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+}

--- a/terraform/modules/cloudfront/outputs.tf
+++ b/terraform/modules/cloudfront/outputs.tf
@@ -1,0 +1,18 @@
+output "certificate_validation_records" {
+  description = "The DNS records required to validate the ACM certificate."
+  value       = { for dvo in aws_acm_certificate.this.domain_validation_options : dvo.resource_record_name => dvo.resource_record_value }
+}
+
+output "cloudfront_dns" {
+  description = "DNS information for the CloudFront distribution needed to create DNS records."
+  value = {
+    name : local.fqdn
+    target : aws_cloudfront_distribution.this.domain_name
+    zone_id : aws_cloudfront_distribution.this.hosted_zone_id
+  }
+}
+
+output "url" {
+  description = "The fully qualified URL for the redirect."
+  value       = local.fqdn
+}

--- a/terraform/modules/cloudfront/templates/function.js.tftpl
+++ b/terraform/modules/cloudfront/templates/function.js.tftpl
@@ -1,0 +1,15 @@
+function handler(event) {
+  const DESTINATION = "${destination}";
+  const STATIC = ${static};
+  const STATUS_CODE = ${status_code};
+
+  const request = event.request;
+
+  return {
+    statusCode: STATUS_CODE,
+    statusDescription: 'Moved Permanently',
+    headers: {
+      "location": { "value": DESTINATION + (STATIC ? '' : request.uri) }
+    }
+  };
+}

--- a/terraform/modules/cloudfront/templates/function.js.tftpl
+++ b/terraform/modules/cloudfront/templates/function.js.tftpl
@@ -5,11 +5,31 @@ function handler(event) {
 
   const request = event.request;
 
+  var queryString = '';
+  if (request.querystring && Object.keys(request.querystring).length > 0) {
+    var params = [];
+    var queryKeys = Object.keys(request.querystring);
+
+    for (var i = 0; i < queryKeys.length; i++) {
+      var key = queryKeys[i];
+      var value = request.querystring[key];
+
+      if (value.multiValue) {
+        for (var j = 0; j < value.multiValue.length; j++) {
+          params.push(key + '=' + value.multiValue[j].value);
+        }
+      } else {
+        params.push(key + '=' + value.value);
+      }
+    }
+    queryString = '?' + params.join('&');
+  }
+
   return {
     statusCode: STATUS_CODE,
     statusDescription: 'Moved Permanently',
     headers: {
-      "location": { "value": DESTINATION + (STATIC ? '' : request.uri) }
+      "location": { "value": DESTINATION + (STATIC ? '' : request.uri) + queryString }
     }
   };
 }

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -1,0 +1,49 @@
+variable "create_records" {
+  type        = bool
+  description = "Create DNS records using Route 53. A hosted zone matching the source domain must exist. If false, the certificate must be manually validated."
+  default     = true
+}
+
+variable "destination" {
+  type        = string
+  description = "Destination for redirects, including scheme (e.g. https://my.domain.com)."
+}
+
+variable "logging_bucket" {
+  description = "The S3 bucket used for logging."
+  type        = string
+}
+
+variable "static" {
+  type        = bool
+  description = "Redirect to the destination without passing the path."
+  default     = false
+}
+
+variable "status_code" {
+  type        = number
+  description = "HTTP status code for the redirect."
+  default     = 301
+
+  validation {
+    condition     = var.status_code == 301 || var.status_code == 302
+    error_message = "Status code must be either 301 or 302."
+  }
+}
+
+variable "source_domain" {
+  type        = string
+  description = "Domain to redirect from. This should match the hosted zone when creating verification records."
+}
+
+variable "source_subdomain" {
+  type        = string
+  description = "Optional subdomain for the source redirect. Required if the fully qualified domain name (FQDN) is a subdomain of the hosted zone domain."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to all resources."
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,6 +16,12 @@ variable "domain_name" {
   default     = "demo.codeforamerica.ai"
 }
 
+variable "redirect_domain" {
+  description = "Optional domain for redirection."
+  type        = string
+  default     = "ada.codeforamerica.ai"
+}
+
 variable "aws_region" {
   description = "AWS Region"
   type        = string


### PR DESCRIPTION
We want a production environment. It will have a new fancy domain, ada.codeforamerica.ai. We want this new domain to redirect to demo.codeforamerica.ai for now. We need a temporary redirect.

This PR adds the OpenTofu configuration for creating a CloudFront redirect. This code is mostly compliments of James A.

- **What additional steps are required to test this branch locally?**

Visit ada.codeforamerica.ai and make sure it redirects to demo.codeforamerica.ai.

- **Are there any areas you would like extra review?**

No

- **Are there any rake tasks to run on production?**

No