### PR TITLE
1337 google analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <%= render partial: "shared/google_analytics_tag"%>
   <title><%= content_for(:title) || "PDF Audit Tool - Code for America" %></title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/app/views/layouts/centered.html.erb
+++ b/app/views/layouts/centered.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <%= render partial: "shared/google_analytics_tag"%>
     <title><%= content_for(:title) || "PDF Audit Tool - Code for America" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/app/views/shared/_google_analytics_tag.html.erb
+++ b/app/views/shared/_google_analytics_tag.html.erb
@@ -1,0 +1,10 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV.fetch("GOOGLE_ANALYTICS_KEY", "") %>"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+        dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', '<%= ENV.fetch("GOOGLE_ANALYTICS_KEY", "") %>');
+</script>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -65,6 +65,10 @@ module "secrets" {
         password = ""
       })
     }
+    google_analytics = {
+      description = "Optional Google Analytics key."
+      name        = "/asap-pdf/production/GOOGLE_ANALYTICS_KEY"
+    }
     google = {
       description = "Optional Google API key."
       name        = "/asap-pdf/production/GOOGLE_AI_KEY"
@@ -161,6 +165,7 @@ module "ecs" {
   smtp_user_secret_arn        = "${module.secrets.secrets["smtp"].secret_arn}:user"
   smtp_password_secret_arn    = "${module.secrets.secrets["smtp"].secret_arn}:password"
   redis_url_secret_arn        = "${module.secrets.secrets["redis"].secret_arn}:url"
+  google_analytics_key_arn    = module.secrets.secrets["google_analytics"].secret_arn
 
   vpc_id            = module.networking.vpc_id
   private_subnets   = module.networking.private_subnet_ids

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -45,6 +45,7 @@ module "fargate_service" {
     SMTP_ENDPOINT : var.smtp_endpoint_secret_arn,
     SMTP_USER : var.smtp_user_secret_arn,
     SMTP_PASSWORD : var.smtp_password_secret_arn,
+    GOOGLE_ANALYTICS_KEY : var.google_analytics_key_arn,
   }
 }
 
@@ -71,6 +72,7 @@ resource "aws_iam_policy" "ecs_task_secrets_policy" {
           var.smtp_endpoint_secret_arn,
           var.smtp_user_secret_arn,
           var.smtp_password_secret_arn,
+          var.google_analytics_key_arn,
         ]
       }
     ]

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -59,6 +59,11 @@ variable "smtp_password_secret_arn" {
   type        = string
 }
 
+variable "google_analytics_key_arn" {
+  description = "ARN of the Google Analytics key"
+  type        = string
+}
+
 variable "redis_url_secret_arn" {
   description = "ARN of the Redis URL secret in Secrets Manager"
   type        = string


### PR DESCRIPTION
We'd like to be able to track usage of the ASAP app. We should add Google Analytics.

This PR adds Google Analytics to anonymous and authenticated pages of the app. It also adds OpenTofu configuration for a AWS Secret to store the Google Analytics key.

- **What additional steps are required to test this branch locally?**

1. Pull the branch and run the app.
2. Check the source of the page for the Google Analytics tag code.

- **Are there any areas you would like extra review?**

Nope

- **Are there any rake tasks to run on production?**

No