### PR TITLE
Asap 214 better missing document strategies

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -140,7 +140,7 @@ class DocumentsController < AuthenticatedController
 
   def handle_pdf_error(error_code, error_message)
     Rails.logger.error("PDF fetch error: #{error_code} - #{error_message}")
-    render "shared/iframe_error", layout: "simple", locals: {document: @document, error_code: error_code, error_message: error_message}
+    render "shared/iframe_error", layout: "simple", locals: {document: @document, error_code: error_code, error_message: error_message}, formats: [:html]
   end
 
   def sort_direction

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -42,7 +42,7 @@ class DocumentsController < AuthenticatedController
   rescue HTTParty::Error => e
     handle_pdf_error(e.http_code, e.message)
   rescue => e
-    handle_pdf_error("Unknown Error", e.message)
+    handle_pdf_error(nil, e.message)
   end
 
   def update_document_category
@@ -139,6 +139,7 @@ class DocumentsController < AuthenticatedController
   end
 
   def handle_pdf_error(error_code, error_message)
+    error_code ||= "unknown"
     Rails.logger.error("PDF fetch error: #{error_code} - #{error_message}")
     render "shared/iframe_error", layout: "simple", locals: {document: @document, error_code: error_code, error_message: error_message}, formats: [:html]
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -37,12 +37,12 @@ class DocumentsController < AuthenticatedController
                 disposition: "inline; filename=\"#{@document.file_name}\"",
                 filename: @document.file_name
     else
-      handle_pdf_error("#{response.code} - #{response.message}")
+      handle_pdf_error(response.code, response.message)
     end
     rescue HTTParty::Error => e
-      handle_pdf_error("#{e.http_code} - #{e.message}")
+      handle_pdf_error(e.http_code, e.message)
     rescue => e
-      handle_pdf_error(e.message)
+      handle_pdf_error("Unknown Error", e.message)
   end
 
   def update_document_category
@@ -138,9 +138,9 @@ class DocumentsController < AuthenticatedController
     end
   end
 
-  def handle_pdf_error(error_message)
-    Rails.logger.error("PDF fetch error: #{error_message}")
-    render 'shared/iframe_error', layout: 'simple', locals: {document: @document, error: error_message}
+  def handle_pdf_error(error_code, error_message)
+    Rails.logger.error("PDF fetch error: #{error_code} - #{error_message}")
+    render 'shared/iframe_error', layout: 'simple', locals: {document: @document, error_code: error_code, error_message: error_message}
   end
 
   def sort_direction

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -33,16 +33,16 @@ class DocumentsController < AuthenticatedController
     response = HTTParty.get(@document.normalized_url)
     if response.success?
       send_data response.body,
-                type: "application/pdf",
-                disposition: "inline; filename=\"#{@document.file_name}\"",
-                filename: @document.file_name
+        type: "application/pdf",
+        disposition: "inline; filename=\"#{@document.file_name}\"",
+        filename: @document.file_name
     else
       handle_pdf_error(response.code, response.message)
     end
-    rescue HTTParty::Error => e
-      handle_pdf_error(e.http_code, e.message)
-    rescue => e
-      handle_pdf_error("Unknown Error", e.message)
+  rescue HTTParty::Error => e
+    handle_pdf_error(e.http_code, e.message)
+  rescue => e
+    handle_pdf_error("Unknown Error", e.message)
   end
 
   def update_document_category
@@ -140,7 +140,7 @@ class DocumentsController < AuthenticatedController
 
   def handle_pdf_error(error_code, error_message)
     Rails.logger.error("PDF fetch error: #{error_code} - #{error_message}")
-    render 'shared/iframe_error', layout: 'simple', locals: {document: @document, error_code: error_code, error_message: error_message}
+    render "shared/iframe_error", layout: "simple", locals: {document: @document, error_code: error_code, error_message: error_message}
   end
 
   def sort_direction

--- a/app/views/documents/_modal_content.html.erb
+++ b/app/views/documents/_modal_content.html.erb
@@ -48,6 +48,10 @@
               <div class="text-sm text-gray-900 break-words whitespace-normal"><%= document.file_name %></div>
             </div>
             <div class="border-t pt-4">
+              <div class="text-sm font-medium text-gray-500 mb-1">Document Url</div>
+              <div class="text-sm text-gray-900"><%= document.url %></div>
+            </div>
+            <div class="border-t pt-4">
               <div class="text-sm font-medium text-gray-500 mb-1">Last Modified</div>
               <div class="text-sm text-gray-900"><%= document.modification_date&.strftime("%B %d, %Y") %></div>
             </div>
@@ -92,6 +96,18 @@
               <div class="text-sm font-medium text-gray-500 mb-1">Author</div>
               <div class="text-sm text-gray-900">
                 <%= format_metadata(document.author) %>
+              </div>
+            </div>
+            <div class="border-t pt-4 overflow-scroll">
+              <div class="text-sm font-medium text-gray-500 mb-1">Found on Pages</div>
+              <div class="text-sm text-gray-900">
+                <% if document.source.present? %>
+                  <ul>
+                    <% document.source.each do | source | %>
+                      <li class="whitespace-nowrap"><%= source %></li>
+                    <% end %>
+                  </ul>
+                <% end %>
               </div>
             </div>
             <div class="border-t pt-4">

--- a/app/views/documents/_modal_content.html.erb
+++ b/app/views/documents/_modal_content.html.erb
@@ -47,9 +47,11 @@
               <div class="text-sm font-medium text-gray-500 mb-1">File Name</div>
               <div class="text-sm text-gray-900 break-words whitespace-normal"><%= document.file_name %></div>
             </div>
-            <div class="border-t pt-4">
+            <div class="border-t pt-4 overflow-scroll">
               <div class="text-sm font-medium text-gray-500 mb-1">Document Url</div>
-              <div class="text-sm text-gray-900"><%= document.url %></div>
+              <div class="text-sm text-gray-900 whitespace-nowrap">
+                <a class="text-primary" href="<%= document.url %>" target="_blank"><%= document.url %></a>
+              </div>
             </div>
             <div class="border-t pt-4">
               <div class="text-sm font-medium text-gray-500 mb-1">Last Modified</div>
@@ -104,7 +106,9 @@
                 <% if document.source.present? %>
                   <ul>
                     <% document.source.each do | source | %>
-                      <li class="whitespace-nowrap"><%= source %></li>
+                      <li class="whitespace-nowrap">
+                        <a class="text-primary" href="<%= source %>" target="_blank"><%= source %></a>
+                      </li>
                     <% end %>
                   </ul>
                 <% end %>

--- a/app/views/layouts/simple.html.erb
+++ b/app/views/layouts/simple.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= content_for(:title) || "PDF Audit Tool - Code for America" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= yield :head %>
+    <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" rel="stylesheet">
+    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
+    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+    <%= favicon_link_tag asset_path('favicon.png') %>
+    <%# Includes all stylesheet files in app/assets/stylesheets %>
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  </head>
+  <body data-theme="autumn" class="min-h-screen">
+    <main>
+      <%= yield %>
+    </main>
+  </body>
+</html>

--- a/app/views/shared/iframe_error.html.erb
+++ b/app/views/shared/iframe_error.html.erb
@@ -1,9 +1,13 @@
+<h3 class="mb-4 text-md font-semibold">ASAP Document <%= error_code %></h3>
 <div class="text-sm">
-  <p class="mb-4 font-semibold">The document, "<%= document.file_name %>" produced the following error: <%= error %></p>
-  <p class="mb-4">We can't be sure, but one of the following is likely true:</p>
-  <ul class="list-disc ml-4">
-    <li>The document has been moved, removed or unpublished.</li>
-    <li>Your document server or a related firewall has blocked this app.</li>
-    <li>You or your document server are experiencing netowrk issues.</li>
+  <p class="mb-4 font-semibold">Something's not right.</p>
+  <p class="mb-4">We couldn't open your document because of the following error: <%= error_code %>
+    - <%= error_message %></p>
+  <ul class="ml-4 mb-4 list-disc">
+    <li>The document might have been <span class="font-semibold">moved or deleted.</span></li>
+    <li>Your <span class="font-semibold">firewall or document server is blocking</span> our app.</li>
+    <li>There could be a <span class="font-semibold">temporary network problem</span> on your end.</li>
   </ul>
+  <p>To troubleshoot this error, please contact the document owner for access, check your permissions for this document,
+    or verify your login status.</p>
 </div>

--- a/app/views/shared/iframe_error.html.erb
+++ b/app/views/shared/iframe_error.html.erb
@@ -1,0 +1,9 @@
+<div class="text-sm">
+  <p class="mb-4 font-semibold">The document, "<%= document.file_name %>" produced the following error: <%= error %></p>
+  <p class="mb-4">We can't be sure, but one of the following is likely true:</p>
+  <ul class="list-disc ml-4">
+    <li>The document has been moved, removed or unpublished.</li>
+    <li>Your document server or a related firewall has blocked this app.</li>
+    <li>You or your document server are experiencing netowrk issues.</li>
+  </ul>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -224,7 +224,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 2.weeks
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.


### PR DESCRIPTION
When a stakeholder unpublished or moves a document it's not clear what's going on in the app. Right now we just show a vague error message. We want something more robust.

We also think it would be good to explicitly show the document url and sources. Linking directly to the document causes an odd user interaction for urls that automatically force the download of the link. Showing the fields on the "PDF Details" tab seems like a good compromise.

This PR adds a nicely formatted message, when a document returns an error. It also adds the document urls and sources to the "PDF Details" tab.

- **What additional steps are required to test this branch locally?**

1. Create a site for Georgia Department of Revenue
2. Run the import command for your site. Something like: ` bin/rake 'documents:import_documents[3, db/seeds/site_documents/dor_georgia.csv]'`
3. Several of the Georgia documents entitled "Powerpoint" on the first page return 403s. Try opening their modals.

- **Are there any areas you would like extra review?**

Just the above.

- **Are there any rake tasks to run on production?**

No