### PR TITLE
Break up the document inference prompts into two prompts

### DIFF
--- a/python_components/document_inference/document_inference/prompts.py
+++ b/python_components/document_inference/document_inference/prompts.py
@@ -33,6 +33,63 @@ The attached jpeg documents represent a PDF. Analyze the PDF document informatio
 """
 
 
+RECOMMENDATION_ARCHIVAL = """
+# Government PDF ADA Compliance Exception Analyzer
+
+You are an AI assistant specializing in ADA compliance analysis. Your task is to analyze government PDF documents and determine whether they qualify for an exception under the Department of Justice"s 2024 final rule on web content and mobile app accessibility.
+
+## Context
+
+The Department of Justice published a final rule updating regulations for Title II of the Americans with Disabilities Act (ADA). This rule requires state and local governments to ensure their web content and mobile apps are accessible to people with disabilities according to WCAG 2.1, Level AA standards. However, certain PDF documents may qualify for exceptions.
+
+## Your Task
+
+The attached jpeg documents represent a PDF. Analyze the PDF document information and determine whether it qualifies for an exception from WCAG 2.1, Level AA compliance requirements under the following exception category. Please use plain language and avoid technical jargon:
+
+**Archived Web Content Exception** - Applies when ALL of these conditions are met:
+   - Created before the compliance date April 24, 2026
+   - Kept only for reference, research, or recordkeeping
+   - Could be stored in a special area for archived content
+   - Has not been changed since it was archived
+
+## Document Information
+
+  - Document title: {title}
+  - Document created date: {creation_date}
+  - Document purpose: {purpose}
+  - Document URL: {url}
+"""
+
+
+RECOMMENDATION_APPLICATION = """
+# Government PDF ADA Compliance Exception Analyzer
+
+You are an AI assistant specializing in ADA compliance analysis. Your task is to analyze government PDF documents and determine whether they qualify for an exception under the Department of Justice"s 2024 final rule on web content and mobile app accessibility.
+
+## Context
+
+The Department of Justice published a final rule updating regulations for Title II of the Americans with Disabilities Act (ADA). This rule requires state and local governments to ensure their web content and mobile apps are accessible to people with disabilities according to WCAG 2.1, Level AA standards. However, certain PDF documents may qualify for exceptions.
+
+## Your Task
+
+The attached jpeg documents represent a PDF. Analyze the PDF document information and determine whether it qualifies for an exception from WCAG 2.1, Level AA compliance requirements under the following exception category. Please use plain language and avoid technical jargon:
+
+**Preexisting Conventional Electronic Documents Exception** - Applies when ALL conditions are met:
+   - Document is a PDF file
+   - Document was available on the government"s website or mobile app before the compliance date
+   - HOWEVER: This exception does NOT apply if the document is currently being used by individuals to apply for, access, or participate in government services
+   - For example, this exception would probably apply to a flyer for an event or a sample ballot for a past election, if they were posted before the compliance deadline.
+   - But it would NOT apply to a business license application that was posted before the deadline, but could still be used to apply for a license after the deadline.
+
+## Document Information
+
+  - Document title: {title}
+  - Document created date: {creation_date}
+  - Document purpose: {purpose}
+  - Document URL: {url}
+"""
+
+
 SUMMARY = """
 # PDF Analyzer
 

--- a/python_components/document_inference/document_inference/schemas.py
+++ b/python_components/document_inference/document_inference/schemas.py
@@ -20,3 +20,21 @@ class DocumentRecommendation(BaseModel):
     why_application: str = Field(
         description="An explanation of why the document meets or does not meet exception 2: Preexisting Conventional Electronic Documents Exception"
     )
+
+
+class DocumentRecommendationArchival(BaseModel):
+    is_archival: bool = Field(
+        description="Whether the document meets exception 1: Archived Web Content Exception"
+    )
+    why_archival: str = Field(
+        description="An explanation of why the document meets or does not meet exception 1: Archived Web Content Exception"
+    )
+
+
+class DocumentRecommendationApplication(BaseModel):
+    is_application: bool = Field(
+        description="Whether the document meets exception 2: Preexisting Conventional Electronic Documents Exception"
+    )
+    why_application: str = Field(
+        description="An explanation of why the document meets or does not meet exception 2: Preexisting Conventional Electronic Documents Exception"
+    )


### PR DESCRIPTION
Results on [main branch](https://code-for-america.hex.tech/global/app/ASAP-Evaluation-Dashboard-0307kgWXk2slUqaovViuFf/latest?view=0198af32-6e59-7aaf-881a-2f72dd00b965) versus results on [this PR](https://code-for-america.hex.tech/global/app/ASAP-Evaluation-Dashboard-0307kgWXk2slUqaovViuFf/latest?view=0198af76-d929-7aaf-89d5-46a4aafdc1d1). While this new version has some slight increases to our metrics, I don't believe any differences are significant or meaningful. I added a new tab to our dashboard to do comparisons across branches / commits using bootstrapping to construct confidence intervals in the differences and get p-values.
<img width="1153" height="464" alt="image" src="https://github.com/user-attachments/assets/9053ca28-e5c0-4309-ac8f-3c4b86a28b2a" />

- What additional steps are required to test this branch locally?
Nothing out of the ordinary. You'll need to rebuild the docker containers and run the app. In one terminal:
```
docker compose build --no-cache
docker compose up 
```
And in a separate terminal:
```
bin/rails db:drop ; bin/rails db:migrate ; bin/rails db:setup
bin/dev 
```

- Are there any areas you would like extra review?
Not especially. I think this PR demonstrates that breaking the prompt in two is probably not going to yield significant improvements in performance, and because it also probably increases our token usage, I'd advocate for not merging this. But curious your thoughts and maybe some eyeballs on [this notebook](https://code-for-america.hex.tech/global/hex/ASAP-Evaluation-Dashboard-0307kgWXk2slUqaovViuFf/draft/logic?rhid=01974651-5740-7aa4-9459-763a4a2ec49b).

- Are there any rake tasks to run on production?
None.