### PR TITLE
1337 Fix the production function name.

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -227,7 +227,7 @@ class Document < ApplicationRecord
         lambda_manager = AwsLambdaManager.new(function_url: "http://localhost:9002/2015-03-31/functions/function/invocations")
         api_host = "http://host.docker.internal:3000"
       else
-        aws_env = Rails.env == "production" ? "prod" : Rails.env
+        aws_env = (Rails.env == "production") ? "prod" : Rails.env
         lambda_manager = AwsLambdaManager.new(function_name: "asap-pdf-document-inference-#{aws_env}")
       end
       payload = {
@@ -259,7 +259,7 @@ class Document < ApplicationRecord
       lambda_manager = AwsLambdaManager.new(function_url: "http://localhost:9002/2015-03-31/functions/function/invocations")
       api_host = "http://host.docker.internal:3000"
     else
-      aws_env = Rails.env == "production" ? "prod" : Rails.env
+      aws_env = (Rails.env == "production") ? "prod" : Rails.env
       lambda_manager = AwsLambdaManager.new(function_name: "asap-pdf-document-inference-#{aws_env}")
     end
     payload = {


### PR DESCRIPTION
When we added variables to pivot the lambda function name in rails based on environment, we didn't take the prod vs. production conflict into account. We should do that.