### PR TITLE
Asap 221 migrate off preview model

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -140,19 +140,14 @@ jobs:
 
       - name: Read JSON file and set matrix
         id: set-matrix
-        if: ${{ github.events.inputs.limit_to_document == '' }}
         run: |
-          matrix=$(jq -c '.' ./python_components/evaluation/truthset.json)
+          if [ -z "${{ github.event.inputs.limit_to_document }}" ]; then
+            matrix=$(jq -c '.' ./python_components/evaluation/truthset.json)
+          else
+            matrix=$(jq -c '.[] | select(.file_name == "${{ github.event.inputs.limit_to_document }}")' ./python_components/evaluation/truthset.json)
+          fi
           echo "Matrix data: $matrix"
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
-
-      - name: Read JSON file and set matrix for specific file
-        id: set-matrix
-        if: ${{ github.events.inputs.limit_to_document != '' }}
-        run: |
-          matrix=$(jq -c '.[] | select(.file_name == "${{ github.event.inputs.runs_per_document}}")' ./python_components/evaluation/truthset.json)
-          echo "Matrix data: $matrix"
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT          
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT      
 
       - name: Generate run matrix
         id: set-runs

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -13,8 +13,6 @@ on:
         type: choice
         description: Inference Model
         options:
-          - gpt-5
-          - gpt-5-mini
           - gemini-2.5-pro
           - gemini-2.5-flash
       evaluation_model_name:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -123,6 +123,15 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      - name: Wait for Evaluation Lambda to be Active
+        if: ${{ github.event.inputs.should_rebuild_images == 'true' }}
+        env:
+          FUNCTION_NAME: ${{ vars.FUNCTION_NAME_LAMBDA_EVAL }}
+        run: |
+          echo "Waiting for Lambda function to be active..."
+          aws lambda wait function-updated-v2 --function-name $FUNCTION_NAME
+          echo "Lambda function is now active"
+
       - name: Update Document Inference Evaluation Lambda
         id: update-document-inference-evaluation-lambda
         if: ${{ github.event.inputs.should_rebuild_images == 'true' }}
@@ -135,6 +144,15 @@ jobs:
           aws lambda update-function-code \
              --function-name $FUNCTION_NAME \
              --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Wait for Evaluation Lambda to be Active
+        if: ${{ github.event.inputs.should_rebuild_images == 'true' }}
+        env:
+          FUNCTION_NAME: ${{ vars.FUNCTION_NAME_LAMBDA_EVAL_DOCUMENT_INFERENCE }}
+        run: |
+          echo "Waiting for Lambda function to be active..."
+          aws lambda wait function-updated-v2 --function-name $FUNCTION_NAME
+          echo "Lambda function is now active"
 
       - name: Read JSON file and set matrix
         id: set-matrix

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -13,15 +13,17 @@ on:
         type: choice
         description: Inference Model
         options:
-          - gemini-2.5-pro-preview-03-25
-          - gemini-2.0-flash
-          - gemini-2.0-flash-lite
+          - gemini-2.5-pro
+          - gemini-2.5-flash
+          - gemini-2.5-flash-lite
+          - anthropic/claude-3-5-haiku-latest
+          - anthropic/claude-sonnet-4-0
       evaluation_model_name:
         type: choice
         description: Evaluation Model
         options:
           - gemini-2.5-flash
-          - gemini-2.5-pro-preview-03-25
+          - gemini-2.5-pro
       runs_per_document:
         description: 'Number of times generate evaluations per document'
         required: false

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,6 +15,7 @@ on:
         options:
           - gemini-2.5-pro
           - gemini-2.5-flash
+          - gemini-2.5-flash-lite
           - gpt-5
           - gpt-5-mini
       evaluation_model_name:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -179,6 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     strategy:
+      fail-fast: false
       matrix:
         payload: ${{ fromJson(needs.build.outputs.matrix) }}
         run: ${{ fromJson(needs.build.outputs.runs) }}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -13,11 +13,10 @@ on:
         type: choice
         description: Inference Model
         options:
+          - gpt-5
+          - gpt-5-mini
           - gemini-2.5-pro
           - gemini-2.5-flash
-          - gemini-2.5-flash-lite
-          - anthropic/claude-3-5-haiku-latest
-          - anthropic/claude-sonnet-4-0
       evaluation_model_name:
         type: choice
         description: Evaluation Model

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -144,7 +144,7 @@ jobs:
           if [ -z "${{ github.event.inputs.limit_to_document }}" ]; then
             matrix=$(jq -c '.' ./python_components/evaluation/truthset.json)
           else
-            matrix=$(jq -c '.[] | select(.file_name == "${{ github.event.inputs.limit_to_document }}")' ./python_components/evaluation/truthset.json)
+            matrix=$(jq -c '[.[] | select(.file_name == "${{ github.event.inputs.limit_to_document }}")]' ./python_components/evaluation/truthset.json)
           fi
           echo "Matrix data: $matrix"
           echo "matrix=$matrix" >> $GITHUB_OUTPUT      

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -31,7 +31,7 @@ on:
       limit_to_document:
         description: 'Optional document name from truthset file to limit by'
         required: false
-        default: '1'
+        default: ''
         type: string
       should_rebuild_images:
         description: 'Rebuild and push images'

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: '1'
         type: string
+      limit_to_document:
+        description: 'Optional document name from truthset file to limit by'
+        required: false
+        default: '1'
+        type: string
       should_rebuild_images:
         description: 'Rebuild and push images'
         type: boolean
@@ -135,10 +140,19 @@ jobs:
 
       - name: Read JSON file and set matrix
         id: set-matrix
+        if: ${{ github.events.inputs.limit_to_document == '' }}
         run: |
           matrix=$(jq -c '.' ./python_components/evaluation/truthset.json)
           echo "Matrix data: $matrix"
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+      - name: Read JSON file and set matrix for specific file
+        id: set-matrix
+        if: ${{ github.events.inputs.limit_to_document != '' }}
+        run: |
+          matrix=$(jq -c '.[] | select(.file_name == "${{ github.event.inputs.runs_per_document}}")' ./python_components/evaluation/truthset.json)
+          echo "Matrix data: $matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT          
 
       - name: Generate run matrix
         id: set-runs

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,6 +15,8 @@ on:
         options:
           - gemini-2.5-pro
           - gemini-2.5-flash
+          - gpt-5
+          - gpt-5-mini
       evaluation_model_name:
         type: choice
         description: Evaluation Model

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -17,6 +17,8 @@ class ConfigurationsController < AuthenticatedController
     @config["google_ai_api_key"] = response.secret_string if response.present?
     response = @secret_manager.get_secret!(@secret_names[:anthropic_api])
     @config["anthropic_api_key"] = response.secret_string if response.present?
+    response = @secret_manager.get_secret!(@secret_names[:openai_api])
+    @config["openai_api"] = response.secret_string if response.present?
     response = @secret_manager.get_secret!(@secret_names[:google_eval_service_account])
     @config["google_evaluation_service_account_credentials"] = response.secret_string if response.present?
     response = @secret_manager.get_secret!(@secret_names[:google_eval_sheet_id])
@@ -28,6 +30,7 @@ class ConfigurationsController < AuthenticatedController
   def update
     @secret_manager.set_secret!(@secret_names[:google_api], params.dig(:config, :google_ai_api_key))
     @secret_manager.set_secret!(@secret_names[:anthropic_api], params.dig(:config, :anthropic_api_key))
+    @secret_manager.set_secret!(@secret_names[:openai_api], params.dig(:config, :openai_api))
     @secret_manager.set_secret!(@secret_names[:asap_api_user], Rails.application.credentials.config[:api_user])
     @secret_manager.set_secret!(@secret_names[:asap_api_password], Rails.application.credentials.config[:api_password])
     @secret_manager.set_secret!(@secret_names[:google_eval_service_account], params.dig(:config, :google_evaluation_service_account_credentials))

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -234,7 +234,7 @@ class Document < ApplicationRecord
         lambda_manager = AwsLambdaManager.new(function_name: "asap-pdf-document-inference-#{aws_env}")
       end
       payload = {
-        model_name: "gemini-2.0-flash",
+        model_name: "gemini-2.5-flash",
         documents: [{id: id, title: file_name, url: normalized_url, purpose: document_category}],
         page_limit: 7,
         inference_type: "summary",
@@ -266,7 +266,7 @@ class Document < ApplicationRecord
       lambda_manager = AwsLambdaManager.new(function_name: "asap-pdf-document-inference-#{aws_env}")
     end
     payload = {
-      model_name: "gemini-2.5-pro-preview-03-25",
+      model_name: "gemini-2.5-pro",
       documents: [{id: id, title: file_name, url: normalized_url, purpose: document_category, creation_date: creation_date}],
       page_limit: 7,
       inference_type: "exception",

--- a/app/views/configurations/edit.html.erb
+++ b/app/views/configurations/edit.html.erb
@@ -59,6 +59,28 @@
               </div>
             </div>
             <div class="form-control w-full">
+              <%= f.label :openai_api, "OpenAI API Key", class: "label" %>
+              <div class="mt-2">
+                <div class="join w-full" data-controller="password-toggle">
+                  <%= f.password_field :openai_api,
+                                       value: @config["openai_api"],
+                                       autocomplete: "new-password",
+                                       class: "input input-bordered join-item w-full font-mono",
+                                       data: { password_toggle_target: "input" } %>
+                  <button type="button" class="btn join-item" data-action="click->password-toggle#toggle">
+                    <i class="fas fa-eye" data-password-toggle-target="icon"></i>
+                  </button>
+                </div>
+                <div class="mt-2 text-sm text-gray-600">
+                  <p>Need an OpenAI API key?
+                    <%= link_to "Generate one here", "https://openai.com/api/",
+                                target: "_blank",
+                                class: "link link-primary" %>
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="form-control w-full">
               <%= f.label :google_evaluation_service_account_credentials, "Google Credentials JSON (Evaluation)", class: "label" %>
               <div class="mt-2">
                 <%= f.text_area :google_evaluation_service_account_credentials,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,6 +46,7 @@ Rails.application.configure do
     asap_api_password: "asap-pdf/staging/RAILS_API_PASSWORD",
     google_api: "asap-pdf/staging/GOOGLE_AI_KEY",
     anthropic_api: "asap-pdf/staging/ANTHROPIC_KEY",
+    openai_api: "asap-pdf/staging/OPENAI_KEY",
     google_eval_service_account: "asap-pdf/staging/GOOGLE_SERVICE_ACCOUNT",
     google_eval_sheet_id: "asap-pdf/staging/GOOGLE_SHEET_ID_EVALUATION"
   }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,7 @@ Rails.application.configure do
     asap_api_password: "asap-pdf/staging/RAILS_API_PASSWORD",
     google_api: "asap-pdf/staging/GOOGLE_AI_KEY",
     anthropic_api: "asap-pdf/staging/ANTHROPIC_KEY",
+    openai_api: "asap-pdf/staging/OPENAI_KEY",
     google_eval_service_account: "asap-pdf/staging/GOOGLE_SERVICE_ACCOUNT",
     google_eval_sheet_id: "asap-pdf/staging/GOOGLE_SHEET_ID_EVALUATION"
   }

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -158,6 +158,7 @@ def document_inference_summary(
         attachments=attachments,
         schema=DocumentSummarySchema.model_json_schema(),
         stream=False,
+        reasoning_effort="minimal"
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
@@ -183,6 +184,7 @@ def document_inference_recommendation(
         attachments=attachments,
         schema=DocumentRecommendation.model_json_schema(),
         stream=False,
+        reasoning_effort="minimal"
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -157,8 +157,7 @@ def document_inference_summary(
         populated_prompt,
         attachments=attachments,
         schema=DocumentSummarySchema.model_json_schema(),
-        stream=False,
-        reasoning_effort="minimal"
+        stream=False
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
@@ -183,8 +182,7 @@ def document_inference_recommendation(
         populated_prompt,
         attachments=attachments,
         schema=DocumentRecommendation.model_json_schema(),
-        stream=False,
-        reasoning_effort="minimal"
+        stream=False
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -156,8 +156,7 @@ def document_inference_summary(
     response = model.prompt(
         populated_prompt,
         attachments=attachments,
-        schema=DocumentSummarySchema.model_json_schema(),
-        stream=False
+        schema=DocumentSummarySchema.model_json_schema()
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
@@ -181,8 +180,7 @@ def document_inference_recommendation(
     response = model.prompt(
         populated_prompt,
         attachments=attachments,
-        schema=DocumentRecommendation.model_json_schema(),
-        stream=False
+        schema=DocumentRecommendation.model_json_schema()
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -153,11 +153,20 @@ def document_inference_summary(
     num_attachments = len(attachments)
     logger.info(f"Created {num_attachments} images.")
     populated_prompt = SUMMARY.format(**document)
-    response = model.prompt(
-        populated_prompt,
-        attachments=attachments,
-        schema=DocumentSummarySchema.model_json_schema(),
-    )
+    if "gpt" in model.model_id:
+        response = model.prompt(
+            populated_prompt,
+            attachments=attachments,
+            schema=DocumentSummarySchema.model_json_schema(),
+            stream=False,
+            reasoning_effort="minimal"
+        )
+    else:
+        response = model.prompt(
+            populated_prompt,
+            attachments=attachments,
+            schema=DocumentSummarySchema.model_json_schema(),
+        )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
     structured_output_model = DocumentSummarySchema.model_validate(response_json)
@@ -177,11 +186,20 @@ def document_inference_recommendation(
     num_attachments = len(attachments)
     logger.info(f"Created {num_attachments} images.")
     populated_prompt = RECOMMENDATION.format(**document)
-    response = model.prompt(
-        populated_prompt,
-        attachments=attachments,
-        schema=DocumentRecommendation.model_json_schema(),
-    )
+    if "gpt" in model.model_id:
+        response = model.prompt(
+            populated_prompt,
+            attachments=attachments,
+            schema=DocumentRecommendation.model_json_schema(),
+            stream=False,
+            reasoning_effort="minimal"
+        )
+    else:
+        response = model.prompt(
+            populated_prompt,
+            attachments=attachments,
+            schema=DocumentRecommendation.model_json_schema(),
+        )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
     structured_output_model = DocumentRecommendation.model_validate(response_json)

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -157,6 +157,7 @@ def document_inference_summary(
         populated_prompt,
         attachments=attachments,
         schema=DocumentSummarySchema.model_json_schema(),
+        stream=False,
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
@@ -181,6 +182,7 @@ def document_inference_recommendation(
         populated_prompt,
         attachments=attachments,
         schema=DocumentRecommendation.model_json_schema(),
+        stream=False,
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -156,7 +156,7 @@ def document_inference_summary(
     response = model.prompt(
         populated_prompt,
         attachments=attachments,
-        schema=DocumentSummarySchema.model_json_schema()
+        schema=DocumentSummarySchema.model_json_schema(),
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")
@@ -180,7 +180,7 @@ def document_inference_recommendation(
     response = model.prompt(
         populated_prompt,
         attachments=attachments,
-        schema=DocumentRecommendation.model_json_schema()
+        schema=DocumentRecommendation.model_json_schema(),
     )
     response_json = json.loads(response.text())
     logger.info("Inference complete. Validating response.")

--- a/python_components/document_inference/document_inference/helpers.py
+++ b/python_components/document_inference/document_inference/helpers.py
@@ -159,7 +159,7 @@ def document_inference_summary(
             attachments=attachments,
             schema=DocumentSummarySchema.model_json_schema(),
             stream=False,
-            reasoning_effort="minimal"
+            reasoning_effort="minimal",
         )
     else:
         response = model.prompt(
@@ -192,7 +192,7 @@ def document_inference_recommendation(
             attachments=attachments,
             schema=DocumentRecommendation.model_json_schema(),
             stream=False,
-            reasoning_effort="minimal"
+            reasoning_effort="minimal",
         )
     else:
         response = model.prompt(

--- a/python_components/document_inference/models.json
+++ b/python_components/document_inference/models.json
@@ -1,4 +1,10 @@
 {
+  "gpt-5": {
+    "key": "asap-pdf/{AWS_ENV}/OPENAI_KEY"
+  },
+  "gpt-5-mini": {
+    "key": "asap-pdf/{AWS_ENV}/OPENAI_KEY"
+  },
   "anthropic/claude-3-5-haiku-latest": {
     "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
   },

--- a/python_components/document_inference/models.json
+++ b/python_components/document_inference/models.json
@@ -2,16 +2,16 @@
   "anthropic/claude-3-5-haiku-latest": {
     "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
   },
-  "gemini-1.5-pro-latest": {
+  "anthropic/claude-sonnet-4-0": {
+    "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
+  },
+  "gemini-2.5-flash-lite": {
     "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
   },
-  "gemini-2.0-flash": {
+  "gemini-2.5-flash": {
     "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
   },
-  "gemini-2.0-flash-lite": {
-    "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
-  },
-  "gemini-2.5-pro-preview-03-25": {
+  "gemini-2.5-pro": {
     "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
   }
 }

--- a/python_components/document_inference/models.json
+++ b/python_components/document_inference/models.json
@@ -11,6 +11,9 @@
   "anthropic/claude-sonnet-4-0": {
     "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
   },
+  "gemini-2.5-flash-lite": {
+    "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
+  },
   "gemini-2.5-flash": {
     "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
   },

--- a/python_components/document_inference/models.json
+++ b/python_components/document_inference/models.json
@@ -5,9 +5,6 @@
   "anthropic/claude-sonnet-4-0": {
     "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
   },
-  "gemini-2.5-flash-lite": {
-    "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
-  },
   "gemini-2.5-flash": {
     "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
   },

--- a/python_components/document_inference/requirements.txt
+++ b/python_components/document_inference/requirements.txt
@@ -7,11 +7,12 @@ flake8==7.1.2
 importlib-metadata==8.0.0
 inflect==7.3.1
 isort==6.0.1
+jaraco-functools==4.3.0
 jaraco.collections==5.1.0
-llm-anthropic==0.15.1
-llm-gemini==0.19.1
-pillow>=11.3.0
+llm-anthropic==0.18
+llm-gemini==0.25
+pillow==11.3.0
 pip-chill==1.0.3
 pymupdf==1.25.5
-requests>=2.32.4
+requests==2.32.5
 tomli==2.0.1

--- a/python_components/evaluation/evaluation/exception/evaluation.py
+++ b/python_components/evaluation/evaluation/exception/evaluation.py
@@ -143,6 +143,8 @@ class EvaluationWrapper(EvaluationWrapperBase):
             input="\n\n".join(details),
         )
         metric.measure(test_case)
+        if type(metric) is None or metric.verdicts is None:
+            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting.")
         details = {
             "verdicts": convert_model_list(metric.verdicts),
             "response": response,
@@ -175,6 +177,8 @@ class EvaluationWrapper(EvaluationWrapperBase):
             actual_output=[response],
         )
         metric.measure(test_case)
+        if type(metric) is None or metric.truths is None or metric.claims is None or metric.verdicts is None:
+            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting.")
         details = {
             "truths": metric.truths,
             "claims": metric.claims,

--- a/python_components/evaluation/evaluation/exception/evaluation.py
+++ b/python_components/evaluation/evaluation/exception/evaluation.py
@@ -53,13 +53,19 @@ class EvaluationWrapper(EvaluationWrapperBase):
         )
         duration = time.time() - start
 
-        output.append(dict(self.result_factory.new({
-            "metric_name": f"inference_duration",
-            "metric_version": 0,
-            "score": duration,
-            "file_name": document.file_name,
-            "inference_model": self.inference_model_name,
-        })))
+        output.append(
+            dict(
+                self.result_factory.new(
+                    {
+                        "metric_name": f"inference_duration",
+                        "metric_version": 0,
+                        "score": duration,
+                        "file_name": document.file_name,
+                        "inference_model": self.inference_model_name,
+                    }
+                )
+            )
+        )
 
         logger.info("Exception check complete. Performing related evaluations.")
         document.ai_exception = result
@@ -145,7 +151,9 @@ class EvaluationWrapper(EvaluationWrapperBase):
             )
             metric.measure(test_case)
         except AttributeError:
-            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting or metric performance.")
+            raise RuntimeError(
+                "Metric measurement failed. This is likely due to rate limiting or metric performance."
+            )
         details = {
             "verdicts": convert_model_list(metric.verdicts),
             "response": response,
@@ -179,7 +187,9 @@ class EvaluationWrapper(EvaluationWrapperBase):
             )
             metric.measure(test_case)
         except AttributeError:
-            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting or metric performance.")
+            raise RuntimeError(
+                "Metric measurement failed. This is likely due to rate limiting or metric performance."
+            )
         details = {
             "truths": metric.truths,
             "claims": metric.claims,

--- a/python_components/evaluation/evaluation/exception/evaluation.py
+++ b/python_components/evaluation/evaluation/exception/evaluation.py
@@ -57,7 +57,7 @@ class EvaluationWrapper(EvaluationWrapperBase):
             dict(
                 self.result_factory.new(
                     {
-                        "metric_name": f"inference_duration",
+                        "metric_name": "inference_duration",
                         "metric_version": 0,
                         "score": duration,
                         "file_name": document.file_name,

--- a/python_components/evaluation/evaluation/exception/evaluation.py
+++ b/python_components/evaluation/evaluation/exception/evaluation.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import List
 
 from deepeval.metrics.multimodal_metrics import MultimodalFaithfulnessMetric
@@ -41,6 +42,7 @@ class EvaluationWrapper(EvaluationWrapperBase):
     async def evaluate(self, document: Document) -> List[Result]:
         output = []
         # Perform inferences that we want to evaluate.
+        start = time.time()
         result = get_inference_for_document(
             document,
             self.inference_model_name,
@@ -49,6 +51,16 @@ class EvaluationWrapper(EvaluationWrapperBase):
             self.aws_env,
             self.page_limit,
         )
+        duration = time.time() - start
+
+        output.append(dict(self.result_factory.new({
+            "metric_name": f"inference_duration",
+            "metric_version": 0,
+            "score": duration,
+            "file_name": document.file_name,
+            "inference_model": self.inference_model_name,
+        })))
+
         logger.info("Exception check complete. Performing related evaluations.")
         document.ai_exception = result
 

--- a/python_components/evaluation/evaluation/summary/evaluation.py
+++ b/python_components/evaluation/evaluation/summary/evaluation.py
@@ -1,5 +1,5 @@
-from typing import List
 import time
+from typing import List
 
 from deepeval.test_case import MLLMTestCase
 from evaluation.summary.rouge_score import METRIC_VERSION as ROUGE_VERSION
@@ -32,13 +32,19 @@ class EvaluationWrapper(EvaluationWrapperBase):
             self.page_limit,
         )
         duration = time.time() - start
-        output.append(dict(self.result_factory.new({
-            "metric_name": f"inference_duration",
-            "metric_version": 0,
-            "score": duration,
-            "file_name": document.file_name,
-            "inference_model": self.inference_model_name,
-        })))
+        output.append(
+            dict(
+                self.result_factory.new(
+                    {
+                        "metric_name": f"inference_duration",
+                        "metric_version": 0,
+                        "score": duration,
+                        "file_name": document.file_name,
+                        "inference_model": self.inference_model_name,
+                    }
+                )
+            )
+        )
         logger.info("Summarization complete. Performing related evaluations.")
         document.ai_summary = result["summary"]
         try:
@@ -49,7 +55,9 @@ class EvaluationWrapper(EvaluationWrapperBase):
             )
             metric.measure(test_case)
         except AttributeError:
-            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting or metric performance.")
+            raise RuntimeError(
+                "Metric measurement failed. This is likely due to rate limiting or metric performance."
+            )
         details = {
             "truths": metric.truths,
             "claims": metric.claims,

--- a/python_components/evaluation/evaluation/summary/evaluation.py
+++ b/python_components/evaluation/evaluation/summary/evaluation.py
@@ -46,6 +46,7 @@ class EvaluationWrapper(EvaluationWrapperBase):
             )
         )
         logger.info("Summarization complete. Performing related evaluations.")
+        logger.info(result["summary"])
         document.ai_summary = result["summary"]
         try:
             # Begin the DeepEval summary evaluation.

--- a/python_components/evaluation/evaluation/summary/evaluation.py
+++ b/python_components/evaluation/evaluation/summary/evaluation.py
@@ -41,20 +41,15 @@ class EvaluationWrapper(EvaluationWrapperBase):
         })))
         logger.info("Summarization complete. Performing related evaluations.")
         document.ai_summary = result["summary"]
-        # Begin the DeepEval summary evaluation.
-        metric = MultimodalInputSummarization(model=self.evaluation_model)
-        test_case = MLLMTestCase(
-            input=document.images, actual_output=document.ai_summary
-        )
-        metric.measure(test_case)
-        if (type(metric) is None
-                or metric.truths is None
-                or metric.claims is None
-                or metric.assessment_questions is None
-                or metric.coverage_verdicts is None
-                or metric.alignment_verdicts is None
-        ):
-            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting.")
+        try:
+            # Begin the DeepEval summary evaluation.
+            metric = MultimodalInputSummarization(model=self.evaluation_model)
+            test_case = MLLMTestCase(
+                input=document.images, actual_output=document.ai_summary
+            )
+            metric.measure(test_case)
+        except AttributeError:
+            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting or metric performance.")
         details = {
             "truths": metric.truths,
             "claims": metric.claims,

--- a/python_components/evaluation/evaluation/summary/evaluation.py
+++ b/python_components/evaluation/evaluation/summary/evaluation.py
@@ -39,7 +39,6 @@ class EvaluationWrapper(EvaluationWrapperBase):
             "file_name": document.file_name,
             "inference_model": self.inference_model_name,
         })))
-
         logger.info("Summarization complete. Performing related evaluations.")
         document.ai_summary = result["summary"]
         # Begin the DeepEval summary evaluation.
@@ -48,6 +47,14 @@ class EvaluationWrapper(EvaluationWrapperBase):
             input=document.images, actual_output=document.ai_summary
         )
         metric.measure(test_case)
+        if (type(metric) is None
+                or metric.truths is None
+                or metric.claims is None
+                or metric.assessment_questions is None
+                or metric.coverage_verdicts is None
+                or metric.alignment_verdicts is None
+        ):
+            raise RuntimeError("Metric measurement failed. This is likely due to rate limiting.")
         details = {
             "truths": metric.truths,
             "claims": metric.claims,

--- a/python_components/evaluation/evaluation/summary/evaluation.py
+++ b/python_components/evaluation/evaluation/summary/evaluation.py
@@ -36,7 +36,7 @@ class EvaluationWrapper(EvaluationWrapperBase):
             dict(
                 self.result_factory.new(
                     {
-                        "metric_name": f"inference_duration",
+                        "metric_name": "inference_duration",
                         "metric_version": 0,
                         "score": duration,
                         "file_name": document.file_name,

--- a/python_components/evaluation/evaluation/utility/asap_inference.py
+++ b/python_components/evaluation/evaluation/utility/asap_inference.py
@@ -51,18 +51,18 @@ def get_inference_for_document(
     signature = get_signature(session)
     logger.info(f"Created signature. Url is: {url}")
     headers = {
-        "Content-Type": "application/json",  # Changed from application/x-amz-json-1.1
+        "Content-Type": "application/json",
         "Accept": "application/json",
     }
     payload = json.dumps(
         {
             "inference_type": inference_type,
-            "model_name": inference_model_name,  # "gemini-1.5-pro-latest"
+            "model_name": inference_model_name,
             "page_limit": page_number,
             "documents": [
                 {
                     "title": document.file_name,
-                    "id": "000",  # Does this matter?
+                    "id": "000",
                     "creation_date": document.created_date,
                     "purpose": document.category,
                     "url": document.url,

--- a/python_components/evaluation/lambda_function.py
+++ b/python_components/evaluation/lambda_function.py
@@ -18,6 +18,7 @@ def handler(event, context):
         utility.helpers.logger.info(event)
         if not isinstance(event, dict):
             raise RuntimeError("Event is not a dictionary, please investigate.")
+        raise RuntimeError("Let's simulate the bad thing!")
         utility.helpers.logger.info("Validating event")
         utility.helpers.validate_event(event)
         utility.helpers.logger.info("Event is valid")

--- a/python_components/evaluation/lambda_function.py
+++ b/python_components/evaluation/lambda_function.py
@@ -106,10 +106,11 @@ def handler(event, context):
             return {"statusCode": 200, "body": output}
     except ValidationError as e:
         message = f"Invalid document supplied to event: {str(e)}"
-        return {"statusCode": 500, "body": message}
+        utility.helpers.logger.error(message)
+        raise
     except Exception as e:
         output = str(e)
         if local_mode:
             output = traceback.format_exc()
         utility.helpers.logger.error(f"Error during execution: {output}")
-        return {"statusCode": 500, "body": output}
+        raise

--- a/python_components/evaluation/lambda_function.py
+++ b/python_components/evaluation/lambda_function.py
@@ -18,7 +18,6 @@ def handler(event, context):
         utility.helpers.logger.info(event)
         if not isinstance(event, dict):
             raise RuntimeError("Event is not a dictionary, please investigate.")
-        raise RuntimeError("Let's simulate the bad thing!")
         utility.helpers.logger.info("Validating event")
         utility.helpers.validate_event(event)
         utility.helpers.logger.info("Event is valid")

--- a/python_components/evaluation/models.json
+++ b/python_components/evaluation/models.json
@@ -1,11 +1,14 @@
 {
-  "gemini-2.5-pro-preview-03-25": {
-    "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
+  "anthropic/claude-3-5-haiku-latest": {
+    "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
   },
-  "gemini-1.5-pro-latest": {
-    "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
+  "anthropic/claude-sonnet-4-0": {
+    "key": "asap-pdf/{AWS_ENV}/ANTHROPIC_KEY"
   },
   "gemini-2.5-flash": {
+    "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
+  },
+  "gemini-2.5-pro": {
     "key": "asap-pdf/{AWS_ENV}/GOOGLE_AI_KEY"
   }
 }

--- a/python_components/evaluation/scripts/ci_invoke_evaluation_lambda.sh
+++ b/python_components/evaluation/scripts/ci_invoke_evaluation_lambda.sh
@@ -34,11 +34,20 @@ aws lambda invoke \
   --function-name $FUNCTION_NAME \
   --cli-binary-format raw-in-base64-out \
   --payload file://"$TMP_PAYLOAD" \
-  "output.json"
+  "output.json" > "aws_response.json"
 
+echo "AWS Response Metadata:"
+cat aws_response.json
+
+echo "Lambda Function Output:"
 cat output.json
 
-if grep -q '"StatusCode": 500' output.json; then
-    echo "Error: Found StatusCode 500 in Lambda responses"
+if grep -q '"FunctionError"' aws_response.json; then
+    echo "Error: Lambda function failed with unhandled exception"
+    exit 1
+fi
+
+if grep -q '"statusCode": 500' output.json; then
+    echo "Error: Found StatusCode 500 in Lambda response"
     exit 1
 fi

--- a/terraform/modules/asap_pdf/main.tf
+++ b/terraform/modules/asap_pdf/main.tf
@@ -55,6 +55,9 @@ module "secrets" {
     ANTHROPIC_KEY = {
       description = "Optional Anthropic API key"
     }
+    OPENAI_KEY = {
+      description = "Optional OpenAI API key"
+    }
     RAILS_API_USER = {
       description = "The Rails API user to pass to our python components"
     }
@@ -169,6 +172,7 @@ module "lambda" {
   document_inference_evaluation_ecr_repository_url = module.deployment.document_inference_evaluation_ecr_repository_url
   secret_google_ai_key_arn                         = module.secrets.secrets["GOOGLE_AI_KEY"].secret_arn
   secret_anthropic_key_arn                         = module.secrets.secrets["ANTHROPIC_KEY"].secret_arn
+  secret_openai_key_arn                            = module.secrets.secrets["OPENAI_KEY"].secret_arn
   secret_rails_api_user                            = module.secrets.secrets["RAILS_API_USER"].secret_arn
   secret_rails_api_password                        = module.secrets.secrets["RAILS_API_PASSWORD"].secret_arn
   secret_google_service_account_evals_key_arn      = module.secrets.secrets["GOOGLE_SERVICE_ACCOUNT"].secret_arn

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -143,6 +143,7 @@ resource "aws_iam_role_policy" "lambda_secrets" {
         Resource = [
           var.secret_google_ai_key_arn,
           var.secret_anthropic_key_arn,
+          var.secret_openai_key_arn,
           var.secret_rails_api_user,
           var.secret_rails_api_password,
           var.secret_google_service_account_evals_key_arn,

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -43,6 +43,11 @@ variable "secret_anthropic_key_arn" {
   type        = string
 }
 
+variable "secret_openai_key_arn" {
+  description = "Secret arn for our OpenAI creds."
+  type        = string
+}
+
 variable "s3_document_bucket_arn" {
   description = "Secret arn for our Anthropic creds."
   type        = string


### PR DESCRIPTION
The exception check is currently using gemini-2.5-pro-preview-03-25. We should investigate some other models and try to get off the preview.

This PR adds the following:
- Changes summary model from `gemini-flash-2.0` to `gemini-flash-2.5`.
- Changes exception model from `gemini-2.5-pro-preview-03-25` to `gemini-2.5-pro`
- Adds configuration and model support for OpenAI models
- Updates dependencies for document inference
- Improves the evaluation workflow
  - More consistent error handling
  - Waits for images to be deployed to Lambdas
  - Ability to run a specific file
  - Tracking inference duration

## Evaluation
The following two dashboards were used in assessing evaluation results:
* Main dashboard: https://code-for-america.hex.tech/global/app/ASAP-Evaluation-Dashboard-0307kgWXk2slUqaovViuFf/latest
* Supplemental dashboard: https://code-for-america.hex.tech/global/app/Eval-Score-Validation-030Rlb6LuP6iL5zDQynk2A/latest


### Evaluation Results: Summary

The summarization process is currently using `gemini-flash-2.0`. It seems reasonable that the 2.0 family of models will eventually be discontinued. This seemed like a reasonable moment to compare a few other options. I tried running a evaluation of summaries created by `gemini-flash-2.5` and `gemini-flash-lite-2.5`. 

Baseline Values (52e74416d0fe06065e4de8fc3a99485442327968, ~200 samples):
Rouge Mean: 0.38100022576030146
LLM Summarization Mean: 0.23819095477386934

| Model | Inference Duration Mean | Rouge Mean | LLM Summarization Mean |
|---|---|---|---|
| gemini-flash-2.5 (~200 samples, Feature: c3e0b48c24e1c9a5609999666157c7046e4de0fe, 0876604caab20cb17a535fe31c81f7876225d429) | 7.31s | 0.34988729797702706 (-3.1%) | 0.298 (+6%) |
| gemini-flash-lite-2.5 (~200 samples, 0dfb731eb9cea6680eae7a3f145a0c59ae6b0228, dac863e047578c21758e46b23ecea048216bdce6) | 6.7s | 0.35 (-3.5%) | 0.27 (+2.8%) |

Given the speed and metric changes, `gemini-flash-2.5` seems like a safe move for summarization. The drop in rouge score and increase in llm summarization metric essentially wash out. This change may be random, though ttest values suggest otherwise. It may also be related to increased reasoning capacity in the model, allowing summarization with less direct regurgitation.

I wanted to try gpt-5-mini for summarization, but was having issues running the summarization metric with output from gpt-5-mini. This could have been severe rate limiting by Google. The summarization metric does make at least four LLM calls per document. Here is [a ticket](https://codeforamerica.atlassian.net/jira/software/c/projects/ASAP/boards/54/backlog?selectedIssue=ASAP-224) to explore and possibly replace this approach.

### Evaluation Results: Exception Check

The evaluation process is currently using the `gemini-2.5-pro-preview-03-25` model, which feels like it could be discontinued at any time. I tried running evaluation exception checks with `gemini-pro-2.5` and `gpt-5` with default the reasoning setting.  

Baseline Values (b7fee4e44f5454bbbe1777c670285dc75ad35315, ~200 samples):
Overall accuracy: 98.1%
Exception accuracy: 33%
Archival accuracy: 81.5%

| Model | Inference Duration Mean | Overall Accuracy  |
|---|---|---|
| gemini-pro-2.5 (~200 samples, a44a6ad9dcf6d11a252c48526115fefc6b1b5615) | 18.5s |98.9 (+0.8%) |
| gpt-5 (~100 samples, default reasoning, df0128bada1fa252cc05b066fc1cd621fde7d5ad) | 39.31s | 54.1% (-44%) |

Here is an atomic breakdown of the metrics comparing the two Gemini models:

<img width="870" height="351" alt="Screenshot 2025-09-09 at 3 57 33 PM" src="https://github.com/user-attachments/assets/f8ba6498-a30c-4eba-9279-0d0e5e6b9e60" />

Given the relatively small change in overall accuracy and the individual metrics, changing from `gemini-2.5-pro-preview-03-25` to `gemini-pro-2.5` seems safe. The relatively big drop off in gpt-5 is hard to explain and would probably require more digging around. For now, sticking with Gemini probably makes the most sense.

- What additional steps are required to test this branch locally?

  Rebuild the images `docker-compose build --no-cache`.

- Are there any areas you would like extra review?

The above evaluation results.

- Are there any rake tasks to run on production?

No