### PR TITLE
Add lifecycle policy to all the registries.

### DIFF
--- a/terraform/modules/deployment/main.tf
+++ b/terraform/modules/deployment/main.tf
@@ -65,7 +65,6 @@ resource "aws_ecr_lifecycle_policy" "document_inference" {
   policy     = data.aws_ecr_lifecycle_policy_document.thirty_day_expiration_policy.json
 }
 
-
 resource "aws_ecr_repository" "evaluation" {
   name                 = "${var.project_name}-evaluation-${var.environment}"
   force_delete         = true


### PR DESCRIPTION
Every time we deploy or run the evaluation suite, we create new images that get pushed to our elastic container registry (ECR). As we pay for the storage, we don't want to keep every Lambda image indefinitely. We should add some auto deletion to our repositories.

This PR adds ECR lifecycle policies to our Lambda repositories. The Fargate (Rails app) repository already has a deletion policy. Our policy will remove images after 30 days regardless of tags.

- **What additional steps are required to test this branch locally?**

None

- **Are there any areas you would like extra review?**

No

- **Are there any rake tasks to run on production?**

No