### PR TITLE
Add default site emails to config.

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,4 @@
 class ApplicationMailer < Devise::Mailer
-  default from: "Code for America <admin@ada.codeforamerica.ai>"
-
   layout "mailer"
 
   def new_account_instructions(record, token)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,6 +23,9 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+  config.action_mailer.default_options = {
+    from: "Code for America Dev <dev@ada.codeforamerica.ai>"
+  }
 
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,9 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = {host: "ada.codeforamerica.ai"}
-
+  config.action_mailer.default_options = {
+    from: "Code for America <admin@ada.codeforamerica.ai>"
+  }
   config.i18n.fallbacks = true
   config.active_record.dump_schema_after_migration = false
   config.active_record.attributes_for_inspect = [:id]

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -39,7 +39,9 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = {host: "staging.ada.codeforamerica.ai"}
-
+  config.action_mailer.default_options = {
+    from: "Code for America <admin@staging.ada.codeforamerica.ai>"
+  }
   config.i18n.fallbacks = true
   config.active_record.dump_schema_after_migration = false
   config.active_record.attributes_for_inspect = [:id]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,6 +14,9 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = {host: "example.com"}
   config.action_mailer.perform_deliveries = true
+  config.action_mailer.default_options = {
+    from: "Code for America <admin@ada.codeforamerica.ai>"
+  }
   config.active_support.deprecation = :stderr
 
   config.action_controller.raise_on_missing_callback_actions = true


### PR DESCRIPTION
We are trying to send emails from the production url on staging. That email address is not in our verified senders list. Let's change to the correct url.

This PR moves the default email addresses to environment configuration.