### PR TITLE
Remove unused S3-based storage for documents.

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -185,45 +185,6 @@ class Document < ApplicationRecord
     URI::DEFAULT_PARSER.escape(decoded_url)
   end
 
-  def s3_path
-    "#{site.s3_endpoint_prefix}/#{id}/document.pdf"
-  end
-
-  def s3_bucket
-    @s3_bucket ||= Aws::S3::Resource.new(
-      access_key_id: storage_config[:access_key_id],
-      secret_access_key: storage_config[:secret_access_key],
-      region: storage_config[:region],
-      endpoint: storage_config[:endpoint],
-      force_path_style: storage_config[:force_path_style]
-    ).bucket(storage_config[:bucket])
-  end
-
-  def s3_object
-    s3_bucket.object(s3_path)
-  end
-
-  def file_versions
-    s3_bucket.object_versions(prefix: s3_path)
-  end
-
-  def latest_file
-    file_versions.first
-  end
-
-  def file_version(version_id)
-    s3_object.get(version_id: version_id)
-  end
-
-  def version_metadata(version)
-    {
-      version_id: version.version_id,
-      modification_date: version.modification_date,
-      size: version.size,
-      etag: version.etag
-    }
-  end
-
   def inference_summary!(api_host = nil)
     if summary.nil?
       if Rails.env.to_s == "development" || Rails.env.to_s == "test"
@@ -331,14 +292,6 @@ class Document < ApplicationRecord
       decoded_url = recursive_decode(decoded_url)
     end
     decoded_url
-  end
-
-  def storage_config
-    @storage_config ||= begin
-      config = Rails.application.config.active_storage.service_configurations[Rails.env.to_s]
-      raise "S3 storage configuration not found for #{Rails.env}" unless config
-      config.symbolize_keys
-    end
   end
 
   def set_defaults

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -161,28 +161,6 @@ class Site < ApplicationRecord
     primary_url.sub(/^https?:\/\//, "").sub(/\/$/, "")
   end
 
-  def s3_endpoint_prefix
-    return nil if primary_url.blank?
-
-    uri = URI.parse(primary_url.strip)
-    host = uri.host.downcase
-    host.gsub(/[^a-z0-9]/, "-").squeeze("-").gsub(/^-|-$/, "")
-  end
-
-  def s3_endpoint
-    return nil if s3_endpoint_prefix.nil?
-    File.join(S3_BUCKET, s3_endpoint_prefix)
-  end
-
-  def s3_key_for(filename)
-    File.join(s3_endpoint_prefix, filename)
-  end
-
-  def as_json(options = {})
-    super.except("created_at", "updated_at")
-      .merge("s3_endpoint" => s3_endpoint)
-  end
-
   def discover_documents!(document_data, collect = false)
     return if document_data.empty?
     collection = []

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,15 +7,9 @@ test:
   root: <%= Rails.root.join("tmp/storage") %>
 
 staging:
-  service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: us-east-1
-  bucket: cfa-aistudio-asap-pdf
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
 
 production:
-  service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: us-east-1
-  bucket: cfa-aistudio-asap-pdf
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -63,17 +63,6 @@ RSpec.describe Document, type: :model do
     end
   end
 
-  describe "S3 storage" do
-    let(:site) { create(:site, primary_url: "https://www.city.org") }
-    let(:document) { Document.new(document_category: "Brochure", site: site) }
-
-    describe "#s3_path" do
-      it "generates correct path using site prefix and document id" do
-        expect(document.s3_path).to eq("www-city-org/#{document.id}/document.pdf")
-      end
-    end
-  end
-
   describe "#complexity" do
     let(:simple_document) { create(:document, document_category: "Brochure") }
     let(:complex_document) { create(:document, document_category: "Form") }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -14,23 +14,4 @@ RSpec.describe Site, type: :model do
 
   it { is_expected.to validate_uniqueness_of(:primary_url) }
   it { is_expected.to validate_uniqueness_of(:name) }
-
-  describe "#as_json" do
-    let(:site) { create(:site, primary_url: "https://www.city.org") }
-
-    it "excludes user_id, created_at, and updated_at" do
-      json = site.as_json
-      expect(json.keys).not_to include("user_id", "created_at", "updated_at")
-    end
-
-    it "includes basic attributes" do
-      json = site.as_json
-      expect(json).to include(
-        "id" => site.id,
-        "name" => site.name,
-        "location" => site.location,
-        "primary_url" => site.primary_url
-      )
-    end
-  end
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -15,65 +15,12 @@ RSpec.describe Site, type: :model do
   it { is_expected.to validate_uniqueness_of(:primary_url) }
   it { is_expected.to validate_uniqueness_of(:name) }
 
-  describe "S3 functionality" do
-    describe "#s3_endpoint_prefix" do
-      it "converts primary_url host to dasherized format" do
-        site = build(:site, primary_url: "https://www.city.org")
-        expect(site.s3_endpoint_prefix).to eq("www-city-org")
-      end
-
-      it "handles URLs with multiple subdomains" do
-        site = build(:site, primary_url: "https://docs.sub.city.gov")
-        expect(site.s3_endpoint_prefix).to eq("docs-sub-city-gov")
-      end
-
-      it "handles URLs with dashes" do
-        site = build(:site, primary_url: "https://my-city.org")
-        expect(site.s3_endpoint_prefix).to eq("my-city-org")
-      end
-
-      it "returns nil for blank URL" do
-        site = build(:site, primary_url: nil)
-        expect(site.s3_endpoint_prefix).to be_nil
-      end
-    end
-
-    describe "#s3_endpoint" do
-      it "combines S3_BUCKET with endpoint prefix" do
-        site = build(:site, primary_url: "https://www.city.org")
-        expect(site.s3_endpoint).to eq("s3://cfa-aistudio-asap-pdf/www-city-org")
-      end
-
-      it "returns nil for blank URL" do
-        site = build(:site, primary_url: nil)
-        expect(site.s3_endpoint).to be_nil
-      end
-    end
-
-    describe "#s3_key_for" do
-      it "combines endpoint prefix with filename" do
-        site = build(:site, primary_url: "https://www.city.org")
-        expect(site.s3_key_for("test.pdf")).to eq("www-city-org/test.pdf")
-      end
-
-      it "handles nested paths in filename" do
-        site = build(:site, primary_url: "https://www.city.org")
-        expect(site.s3_key_for("folder/test.pdf")).to eq("www-city-org/folder/test.pdf")
-      end
-    end
-  end
-
   describe "#as_json" do
     let(:site) { create(:site, primary_url: "https://www.city.org") }
 
     it "excludes user_id, created_at, and updated_at" do
       json = site.as_json
       expect(json.keys).not_to include("user_id", "created_at", "updated_at")
-    end
-
-    it "includes s3_endpoint" do
-      json = site.as_json
-      expect(json["s3_endpoint"]).to eq("s3://cfa-aistudio-asap-pdf/www-city-org")
     end
 
     it "includes basic attributes" do


### PR DESCRIPTION
We have some vestigial S3 implementation on the document and site model.  Since we never stored the documents in S3, it's confusing to leave code for that storage around. Let's try to make it more clear what's going on.

This PR removes the document and site model's storage handling code and changes the storage config to use the tmp file system in all environments.