### PR TITLE
security: dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,19 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Add 7 day cooldown period to Dependabot updates to prevent automated installation of newly released packages.