### PR TITLE
Local dev + Dependabot + SES infra fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,16 @@ updates:
   open-pull-requests-limit: 10
   cooldown:
     default-days: 7
+- package-ecosystem: pip
+  directories:
+    - "/python_components/accessibility_scan"
+    - "/python_components/ci"
+    - "/python_components/classifier"
+    - "/python_components/crawler"
+    - "/python_components/document_inference"
+    - "/python_components/evaluation"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     ports:
       - "4566:4566"  # LocalStack edge port
     environment:
+      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?LocalStack now requires an auth token. Get one at https://app.localstack.cloud and set LOCALSTACK_AUTH_TOKEN in your shell or a gitignored .env file.}
       - SERVICES=s3,lambda,logs,secretsmanager
       - AWS_DEFAULT_REGION=us-east-1
       - DOCKER_HOST=unix:///var/run/docker.sock

--- a/terraform/modules/ses/main.tf
+++ b/terraform/modules/ses/main.tf
@@ -4,7 +4,7 @@ data "aws_route53_zone" "domain" {
 
 module "ses" {
   name =  "${var.project_name}-${var.environment}-ses"
-  source = "github.com/cloudposse/terraform-aws-ses"
+  source = "github.com/cloudposse/terraform-aws-ses?ref=v0.25.2"
   domain = var.domain_name
   zone_id = data.aws_route53_zone.domain.id
   verify_domain = true


### PR DESCRIPTION
Three small, independent infra/dev-tooling fixes.

## 1. LocalStack requires an auth token (local dev)
LocalStack's unified image (2026.03.0+) now requires `LOCALSTACK_AUTH_TOKEN`. `docker-compose.yml` now passes it through and **fails fast with actionable guidance** when unset, instead of the cryptic exit-code-55 license error. Set it via a gitignored `.env` or your shell. (CfA qualifies for a free LocalStack OSS license.)

## 2. Dependabot now monitors the Python components
Added a `pip` ecosystem covering all six `python_components/*` manifests (`accessibility_scan`, `ci`, `classifier`, `crawler`, `document_inference`, `evaluation`). Previously only bundler/npm/github-actions were watched, so Python deps got **zero** update PRs or security alerts.

## 3. SES: pin module to stop key rotation
Root cause of the recurring red deploys: `terraform/modules/ses/main.tf` referenced `cloudposse/terraform-aws-ses` with **no version ref** (floating HEAD). An older module version created an auto-expiring SMTP access key (`awsutils_expiring_iam_access_key`, 30-day `max_age`); current upstream creates a plain non-rotating `aws_iam_access_key`. The floating ref made plans nondeterministic and triggered an expiring→regular key migration in CI that needs `iam:DeleteAccessKey`/`iam:CreateAccessKey` — permissions the GitHub Actions role intentionally lacks.

Fix: **pin to `v0.25.2`**, which uses `iam-system-user` 1.2.1 — a stable, non-rotating access key (`iam_create_access_key` defaults to `true`, so the SMTP key is still created). No `max_age` knob is needed; that variable does not exist in v0.25.2. The pin makes plans deterministic and matches what CI was already migrating toward. The old auto-rotation delivered no benefit anyway — it wrote to SSM, disconnected from the Secrets Manager values the app actually reads.

## Validation
- Dependabot YAML parses (4 ecosystems, 6 pip directories)
- SES module pinned to v0.25.2; verified v0.25.2 + iam-system-user 1.2.1 create a non-rotating key with no `max_age` argument (an earlier `iam_access_key_max_age = 0` attempt failed `tofu plan` and was removed)
- LocalStack compose interpolation verified both with and without the token set

🤖 Generated with [Claude Code](https://claude.com/claude-code)