### PR TITLE
security: fix security issues

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,2 @@
 class ApplicationController < ActionController::Base
-  # TODO: REMOVE ME!!!
-  # skip_before_action :verify_authenticity_token
 end

--- a/app/controllers/feedback_items_controller.rb
+++ b/app/controllers/feedback_items_controller.rb
@@ -1,27 +1,41 @@
-class FeedbackItemsController < ApplicationController
+class FeedbackItemsController < AuthenticatedController
   wrap_parameters false
+
   def update_feedback_items
-    begin
-      batch_params["feedback_items"].each do |patched_item|
-        item = FeedbackItem.where(document_inference_id: patched_item["document_inference_id"], user_id: patched_item["user_id"]).first_or_create
-        item.assign_attributes(patched_item)
-        item.save!
-      end
-    rescue
-      return render json: {error: "Error updating feedback items."}, status: :unprocessable_entity
+    batch_params["feedback_items"].each do |patched_item|
+      inference = authorized_inference!(patched_item["document_inference_id"])
+      item = FeedbackItem.where(document_inference_id: inference.id, user_id: current_user.id).first_or_create
+      item.assign_attributes(patched_item)
+      item.save!
     end
     render json: {success: true}
+  rescue ActiveRecord::RecordNotFound
+    render json: {error: "Feedback target not found."}, status: :not_found
+  rescue
+    render json: {error: "Error updating feedback items."}, status: :unprocessable_entity
   end
 
   def delete_items
     batch_params["feedback_items"].each do |patched_item|
-      FeedbackItem.where(document_inference_id: patched_item["document_inference_id"], user_id: patched_item["user_id"]).destroy_all
+      inference = authorized_inference!(patched_item["document_inference_id"])
+      FeedbackItem.where(document_inference_id: inference.id, user_id: current_user.id).destroy_all
     end
+    head :no_content
+  rescue ActiveRecord::RecordNotFound
+    render json: {error: "Feedback target not found."}, status: :not_found
   end
 
   private
 
+  def authorized_inference!(document_inference_id)
+    inference = DocumentInference.find(document_inference_id)
+    unless current_user.is_site_admin? || current_user.site == inference.document.site
+      raise ActiveRecord::RecordNotFound
+    end
+    inference
+  end
+
   def batch_params
-    params.permit(feedback_items: [:id, :document_inference_id, :user_id, :sentiment, :comment]).to_h
+    params.permit(feedback_items: [:document_inference_id, :sentiment, :comment]).to_h
   end
 end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -60,10 +60,13 @@ class SitesController < AuthenticatedController
   end
 
   def workflow_audit_report
+    key = params[:key]
+    key = key.start_with?("/") ? key : "/#{key}"
+    unless authorized_report_location?(params[:bucket_name], key)
+      return render plain: "File not found", status: 404
+    end
     s3_manager = AwsS3Manager.new
     begin
-      key = params[:key]
-      key = key.start_with?("/") ? key : "/#{key}"
       response = s3_manager.get_object!(params[:bucket_name], key)
       send_data response[:body].read,
         filename: File.basename(key),
@@ -78,6 +81,16 @@ class SitesController < AuthenticatedController
   end
 
   private
+
+  # Constrain audit-report downloads to the app's own bucket and to the
+  # requesting site's own reports/<machine_name>/ prefix. @site is the URL's
+  # site, already authorized by ensure_user_site_access. The trailing slash is
+  # load-bearing: without it, slug "revenue" could read "revenue_dept"'s keys.
+  # Returns the same 404 as a missing key so no bucket/key oracle leaks.
+  def authorized_report_location?(bucket_name, normalized_key)
+    bucket_name == Rails.application.config.default_s3_bucket &&
+      normalized_key.start_with?("/reports/#{@site.machine_name}/")
+  end
 
   def site_params
     params.require(:site).permit(:name, :location, :primary_url)

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -3,7 +3,8 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["menu"]
 
-  toggle() {
+  toggle(event) {
+    event.stopPropagation()
     this.menuTarget.classList.toggle("hidden")
   }
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -129,6 +129,13 @@ class Site < ApplicationRecord
   validates :location, presence: true
   validates :primary_url, presence: true, uniqueness: true
   validate :ensure_safe_url
+  validate :machine_name_must_be_unique
+
+  # Filesystem/S3-safe identifier derived from the name. Used to scope this
+  # site's audit-report keys under reports/<machine_name>/.
+  def machine_name
+    name.to_s.downcase.gsub(/\W+/, "_")
+  end
 
   after_initialize :after_initialize
 
@@ -299,7 +306,7 @@ class Site < ApplicationRecord
   def export_document_audit!(current_user)
     assert_s3_manager
     bucket_name = Rails.application.config.default_s3_bucket
-    machine_site_name = name.downcase.gsub(/\W+/, "_")
+    machine_site_name = machine_name
     report_name = "audit_export_#{machine_site_name}_#{Time.now.strftime("%Y-%m-%dT%H-%M-%S")}"
     Tempfile.create([report_name, ".csv"]) do |temp_file|
       CSV.open(temp_file.path, "wb") do |csv|
@@ -319,7 +326,7 @@ class Site < ApplicationRecord
   def get_document_audit_exports!
     assert_s3_manager
     bucket_name = Rails.application.config.default_s3_bucket
-    machine_site_name = name.downcase.gsub(/\W+/, "_")
+    machine_site_name = machine_name
     {
       bucket_name: bucket_name,
       files: @s3_manager.get_files!(bucket_name, "/reports/#{machine_site_name}")
@@ -344,6 +351,16 @@ class Site < ApplicationRecord
   end
 
   private
+
+  # Two distinct names can normalize to the same machine_name (e.g. "SLC Gov"
+  # and "SLC.gov" both become "slc_gov"), which would let them share a
+  # reports/<machine_name>/ prefix and defeat per-site scoping. Guard against it.
+  def machine_name_must_be_unique
+    return if name.blank?
+    if Site.where.not(id: id).any? { |other| other.machine_name == machine_name }
+      errors.add(:name, "conflicts with an existing site's report identifier")
+    end
+  end
 
   def assert_s3_manager
     if @s3_manager.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resources :sites do
     member do
-      get "workflow_audit_report/:id/:bucket_name/*key", to: "sites#workflow_audit_report", format: false, as: :workflow_audit_report
+      get "workflow_audit_report/:bucket_name/*key", to: "sites#workflow_audit_report", format: false, as: :workflow_audit_report
       post :create_workflow_audit_report
     end
     resources :documents do

--- a/python_components/ci/requirements.txt
+++ b/python_components/ci/requirements.txt
@@ -10,7 +10,7 @@ inflect==7.3.1
 isort==6.0.1
 jaraco-functools==4.2.1
 jaraco.collections==5.1.0
-llm==0.26
+llm==0.31.1
 pandas==2.2.3
 pip-chill==1.0.3
 pymupdf==1.25.5

--- a/spec/factories/feedback_items.rb
+++ b/spec/factories/feedback_items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :feedback_item do
+    sentiment { "positive" }
+    comment { "Looks right." }
+    document_inference
+    user
+  end
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -14,4 +14,19 @@ RSpec.describe Site, type: :model do
 
   it { is_expected.to validate_uniqueness_of(:primary_url) }
   it { is_expected.to validate_uniqueness_of(:name) }
+
+  describe "#machine_name" do
+    it "lowercases the name and collapses non-word runs into underscores" do
+      expect(build(:site, name: "SLC.gov").machine_name).to eq("slc_gov")
+    end
+  end
+
+  describe "report-identifier uniqueness" do
+    it "rejects a second site whose name resolves to the same machine_name" do
+      create(:site, name: "SLC Gov")
+      dup = build(:site, name: "SLC.gov")
+      expect(dup).not_to be_valid
+      expect(dup.errors[:name]).to be_present
+    end
+  end
 end

--- a/spec/requests/feedback_items_controller_spec.rb
+++ b/spec/requests/feedback_items_controller_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe FeedbackItemsController, type: :request do
+  include Warden::Test::Helpers
+
+  after { Warden.test_reset! }
+
+  # Request specs carry no CSRF token, so disable forgery protection for this
+  # spec only. Turning it off globally would strip the csrf-token meta tag that
+  # the app's JS depends on, breaking the JS feature specs.
+  around do |example|
+    original = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = false
+    example.run
+    ActionController::Base.allow_forgery_protection = original
+  end
+
+  let(:site) { create(:site) }
+  let(:document) { create(:document, site: site) }
+  let(:inference) { create(:document_inference, document: document) }
+  let(:user) { create(:user, site: site) }
+
+  describe "authentication" do
+    it "returns 401 for an unauthenticated PATCH" do
+      patch update_feedback_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: inference.id, sentiment: "positive"}]},
+        as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(FeedbackItem.count).to eq(0)
+    end
+
+    it "returns 401 for an unauthenticated DELETE" do
+      create(:feedback_item, document_inference: inference, user: user)
+
+      delete delete_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: inference.id}]},
+        as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(FeedbackItem.count).to eq(1)
+    end
+  end
+
+  describe "PATCH update_feedback_items" do
+    before { login_as(user, scope: :user) }
+
+    it "creates feedback owned by the current user" do
+      patch update_feedback_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: inference.id, sentiment: "negative", comment: "off"}]},
+        as: :json
+
+      expect(response).to have_http_status(:ok)
+      item = FeedbackItem.sole
+      expect(item.user).to eq(user)
+      expect(item.sentiment).to eq("negative")
+    end
+
+    it "ignores a body user_id that names another user" do
+      other_user = create(:user, site: site)
+
+      patch update_feedback_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: inference.id, user_id: other_user.id, sentiment: "positive"}]},
+        as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(FeedbackItem.sole.user).to eq(user)
+    end
+
+    it "refuses feedback on an inference belonging to another site" do
+      other_inference = create(:document_inference, document: create(:document, site: create(:site)))
+
+      patch update_feedback_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: other_inference.id, sentiment: "positive"}]},
+        as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(FeedbackItem.count).to eq(0)
+    end
+
+    it "lets a site admin leave feedback across sites" do
+      admin = create(:user, :site_admin)
+      login_as(admin, scope: :user)
+      other_inference = create(:document_inference, document: create(:document, site: create(:site)))
+
+      patch update_feedback_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: other_inference.id, sentiment: "positive"}]},
+        as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(FeedbackItem.sole.user).to eq(admin)
+    end
+  end
+
+  describe "DELETE delete_items" do
+    before { login_as(user, scope: :user) }
+
+    it "removes only the caller's own feedback" do
+      mine = create(:feedback_item, document_inference: inference, user: user)
+      theirs = create(:feedback_item, document_inference: inference, user: create(:user, site: site))
+
+      delete delete_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: inference.id}]},
+        as: :json
+
+      expect(response).to have_http_status(:no_content)
+      expect(FeedbackItem.exists?(mine.id)).to be(false)
+      expect(FeedbackItem.exists?(theirs.id)).to be(true)
+    end
+
+    it "refuses to act on an inference belonging to another site" do
+      other_site = create(:site)
+      other_inference = create(:document_inference, document: create(:document, site: other_site))
+      row = create(:feedback_item, document_inference: other_inference, user: user)
+
+      delete delete_items_feedback_items_path,
+        params: {feedback_items: [{document_inference_id: other_inference.id}]},
+        as: :json
+
+      expect(response).to have_http_status(:not_found)
+      expect(FeedbackItem.exists?(row.id)).to be(true)
+    end
+  end
+end

--- a/spec/requests/sites_controller_spec.rb
+++ b/spec/requests/sites_controller_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe SitesController, type: :request do
 
   describe "GET workflow_audit_report" do
     let(:site) { create(:site) }
-    let(:bucket_name) { "test-bucket" }
-    let(:file_key) { "reports/audit.csv" }
+    let(:bucket_name) { Rails.application.config.default_s3_bucket }
+    let(:file_key) { "reports/#{site.machine_name}/audit.csv" }
     let(:file_content) { "id,name,status\n1,doc1,complete" }
 
     let(:s3_response) do
@@ -16,8 +16,9 @@ RSpec.describe SitesController, type: :request do
       }
     end
 
+    let(:s3_manager) { instance_double(AwsS3Manager) }
+
     before do
-      s3_manager = instance_double(AwsS3Manager)
       allow(AwsS3Manager).to receive(:new).and_return(s3_manager)
       allow(s3_manager).to receive(:get_object!).and_return(s3_response)
     end
@@ -42,11 +43,44 @@ RSpec.describe SitesController, type: :request do
 
       before { login_as(user, scope: :user) }
 
-      it "serves the file" do
+      it "serves a file under its own site's prefix" do
         get workflow_audit_report_site_path(site, bucket_name: bucket_name, key: file_key)
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to eq(file_content)
+      end
+
+      it "refuses a non-default bucket without hitting S3" do
+        expect(s3_manager).not_to receive(:get_object!)
+
+        get workflow_audit_report_site_path(site, bucket_name: "some-other-bucket", key: file_key)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "refuses a key under another site's prefix" do
+        other_site = create(:site)
+
+        get workflow_audit_report_site_path(site, bucket_name: bucket_name, key: "reports/#{other_site.machine_name}/audit.csv")
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "refuses a key outside any reports prefix" do
+        get workflow_audit_report_site_path(site, bucket_name: bucket_name, key: "secrets/credentials.csv")
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "enforces the trailing-slash boundary against sibling prefixes" do
+        revenue = create(:site, name: "Revenue")
+        revenue_user = create(:user, site: revenue)
+        login_as(revenue_user, scope: :user)
+
+        # "revenue" is a prefix of "revenue_dept" — must not be readable.
+        get workflow_audit_report_site_path(revenue, bucket_name: bucket_name, key: "reports/revenue_dept/audit.csv")
+
+        expect(response).to have_http_status(:not_found)
       end
     end
 


### PR DESCRIPTION
We have two high security findings from a recent penetration test. We should fix them to prevent any exploits from occurring. They are loosely related to hardening off the feedback endpoint and s3 bucket and key name enforcement on the reporting feature. 