### PR TITLE
fix(security): bump fargate-service module to 1.14.0

### DIFF
--- a/terraform/config/prod/.terraform.lock.hcl
+++ b/terraform/config/prod/.terraform.lock.hcl
@@ -25,7 +25,7 @@ provider "registry.opentofu.org/cloudposse/awsutils" {
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.100.0"
-  constraints = "~> 5.0, >= 5.44.0"
+  constraints = ">= 2.0.0, >= 3.29.0, >= 4.15.1, >= 5.0.0, ~> 5.0, >= 5.35.0, >= 5.44.0, >= 5.79.0, >= 5.81.0, >= 5.83.0, >= 5.85.0, >= 5.93.0, >= 5.99.0"
   hashes = [
     "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
     "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
@@ -38,42 +38,6 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
     "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
     "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
-  ]
-}
-
-provider "registry.opentofu.org/hashicorp/local" {
-  version     = "2.5.3"
-  constraints = ">= 1.2.0"
-  hashes = [
-    "h1:31Clmfoe7hzkcdgwuhUuGuPGfeG2Ksk+YWcJgzBTN7M=",
-    "zh:32e1d4b0595cea6cda4ca256195c162772ddff25594ab4008731a2ec7be230bf",
-    "zh:48c390af0c87df994ec9796f04ec2582bcac581fb81ed6bb58e0671da1c17991",
-    "zh:4be7289c969218a57b40902e2f359914f8d35a7f97b439140cb711aa21e494bd",
-    "zh:4cf958e631e99ed6c8b522c9b22e1f1b568c0bdadb01dd002ca7dffb1c927764",
-    "zh:7a0132c0faca4c4c96aa70808effd6817e28712bf5a39881666ac377b4250acf",
-    "zh:7d60de08fac427fb045e4590d1b921b6778498eee9eb16f78c64d4c577bde096",
-    "zh:91003bee5981e99ec3925ce2f452a5f743827f9d0e131a86613549c1464796f0",
-    "zh:9fe2fe75977c8149e2515fb30c6cc6cfd57b225d4ce592c570d81a3831d7ffa3",
-    "zh:e210e6be54933ce93e03d0994e520ba289aa01b2c1f70e77afb8f2ee796b0fe3",
-    "zh:e8793e5f9422f2b31a804e51806595f335b827c9a38db18766960464566f21d5",
-  ]
-}
-
-provider "registry.opentofu.org/hashicorp/null" {
-  version     = "3.2.4"
-  constraints = ">= 2.0.0"
-  hashes = [
-    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
-    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
-    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
-    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
-    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
-    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
-    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
-    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
-    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
-    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
-    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
   ]
 }
 

--- a/terraform/config/staging/.terraform.lock.hcl
+++ b/terraform/config/staging/.terraform.lock.hcl
@@ -25,7 +25,7 @@ provider "registry.opentofu.org/cloudposse/awsutils" {
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "5.100.0"
-  constraints = "~> 5.0"
+  constraints = ">= 2.0.0, >= 3.29.0, >= 4.15.1, >= 5.0.0, ~> 5.0, >= 5.35.0, >= 5.44.0, >= 5.79.0, >= 5.81.0, >= 5.83.0, >= 5.85.0, >= 5.93.0, >= 5.99.0"
   hashes = [
     "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
     "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
@@ -38,42 +38,6 @@ provider "registry.opentofu.org/hashicorp/aws" {
     "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
     "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
     "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
-  ]
-}
-
-provider "registry.opentofu.org/hashicorp/local" {
-  version     = "2.5.3"
-  constraints = ">= 1.2.0"
-  hashes = [
-    "h1:31Clmfoe7hzkcdgwuhUuGuPGfeG2Ksk+YWcJgzBTN7M=",
-    "zh:32e1d4b0595cea6cda4ca256195c162772ddff25594ab4008731a2ec7be230bf",
-    "zh:48c390af0c87df994ec9796f04ec2582bcac581fb81ed6bb58e0671da1c17991",
-    "zh:4be7289c969218a57b40902e2f359914f8d35a7f97b439140cb711aa21e494bd",
-    "zh:4cf958e631e99ed6c8b522c9b22e1f1b568c0bdadb01dd002ca7dffb1c927764",
-    "zh:7a0132c0faca4c4c96aa70808effd6817e28712bf5a39881666ac377b4250acf",
-    "zh:7d60de08fac427fb045e4590d1b921b6778498eee9eb16f78c64d4c577bde096",
-    "zh:91003bee5981e99ec3925ce2f452a5f743827f9d0e131a86613549c1464796f0",
-    "zh:9fe2fe75977c8149e2515fb30c6cc6cfd57b225d4ce592c570d81a3831d7ffa3",
-    "zh:e210e6be54933ce93e03d0994e520ba289aa01b2c1f70e77afb8f2ee796b0fe3",
-    "zh:e8793e5f9422f2b31a804e51806595f335b827c9a38db18766960464566f21d5",
-  ]
-}
-
-provider "registry.opentofu.org/hashicorp/null" {
-  version     = "3.2.4"
-  constraints = ">= 2.0.0"
-  hashes = [
-    "h1:i+WKhUHL2REY5EGmiHjfUljJB8UKZ9QdhdM5uTeUhC4=",
-    "zh:1769783386610bed8bb1e861a119fe25058be41895e3996d9216dd6bb8a7aee3",
-    "zh:32c62a9387ad0b861b5262b41c5e9ed6e940eda729c2a0e58100e6629af27ddb",
-    "zh:339bf8c2f9733fce068eb6d5612701144c752425cebeafab36563a16be460fb2",
-    "zh:36731f23343aee12a7e078067a98644c0126714c4fe9ac930eecb0f2361788c4",
-    "zh:3d106c7e32a929e2843f732625a582e562ff09120021e510a51a6f5d01175b8d",
-    "zh:74bcb3567708171ad83b234b92c9d63ab441ef882b770b0210c2b14fdbe3b1b6",
-    "zh:90b55bdbffa35df9204282251059e62c178b0ac7035958b93a647839643c0072",
-    "zh:ae24c0e5adc692b8f94cb23a000f91a316070fdc19418578dcf2134ff57cf447",
-    "zh:b5c10d4ad860c4c21273203d1de6d2f0286845edf1c64319fa2362df526b5f58",
-    "zh:e05bbd88e82e1d6234988c85db62fd66f11502645838fff594a2ec25352ecd80",
   ]
 }
 

--- a/terraform/modules/asap_pdf/main.tf
+++ b/terraform/modules/asap_pdf/main.tf
@@ -112,6 +112,8 @@ module "deployment" {
   document_inference_lambda_arn            = module.lambda.document_inference_lambda_arn
   document_inference_evaluation_lambda_arn = module.lambda.document_inference_evaluation_lambda_arn
   evaluation_lambda_arn                    = module.lambda.evaluation_lambda_arn
+  ecs_execution_role_arn                   = module.ecs.execution_role_arn
+  ecs_task_role_arn                        = module.ecs.task_role_arn
   github_branch                            = var.github_branch
   github_environment                       = var.github_environment
 }

--- a/terraform/modules/deployment/main.tf
+++ b/terraform/modules/deployment/main.tf
@@ -235,9 +235,11 @@ resource "aws_iam_role_policy" "github_actions" {
       {
         Effect = "Allow"
         Action = "iam:PassRole"
+        # Read from the ECS module so an upstream role rename cannot silently
+        # break RegisterTaskDefinition in CI.
         Resource = [
-          "arn:aws:iam::${var.aws_account_id}:role/${var.project_name}-${var.environment}-app-execution",
-          "arn:aws:iam::${var.aws_account_id}:role/${var.project_name}-${var.environment}-app-task"
+          var.ecs_execution_role_arn,
+          var.ecs_task_role_arn
         ]
       },
       {

--- a/terraform/modules/deployment/variables.tf
+++ b/terraform/modules/deployment/variables.tf
@@ -40,6 +40,16 @@ variable "evaluation_lambda_arn" {
   type        = string
 }
 
+variable "ecs_execution_role_arn" {
+  description = "ARN of the ECS task execution role that deployments must pass."
+  type        = string
+}
+
+variable "ecs_task_role_arn" {
+  description = "ARN of the ECS task role that deployments must pass."
+  type        = string
+}
+
 variable "backend_kms_arn" {
   description = "Backend module's KMS key."
   type        = string

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,5 +1,5 @@
 module "fargate_service" {
-  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.6.1"
+  source = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.14.0"
 
   project       = var.project_name
   project_short = var.project_name
@@ -23,6 +23,7 @@ module "fargate_service" {
   create_version_parameter = true
   public                   = true
   health_check_path        = "/up"
+  otel_collector_version   = "v0.49.0"
 
   environment_variables = {
     RAILS_ENV           = var.rails_environment

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -23,6 +23,7 @@ module "fargate_service" {
   create_version_parameter = true
   public                   = true
   health_check_path        = "/up"
+  otel_collector_version   = "v0.49.0"
 
   environment_variables = {
     RAILS_ENV           = var.rails_environment

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -23,7 +23,6 @@ module "fargate_service" {
   create_version_parameter = true
   public                   = true
   health_check_path        = "/up"
-  otel_collector_version   = "v0.49.0"
 
   environment_variables = {
     RAILS_ENV           = var.rails_environment

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -2,3 +2,13 @@ output "cluster_name" {
   description = "Name of the ECS cluster"
   value       = module.fargate_service.cluster_name
 }
+
+output "execution_role_arn" {
+  description = "ARN of the role used to execute tasks"
+  value       = module.fargate_service.execution_role_arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the role attached to running tasks"
+  value       = module.fargate_service.task_role_arn
+}


### PR DESCRIPTION
## Summary
- Preparing to pin the ADOT collector version (Vanta "Fargate deploys version-controlled images") requires bumping the `tofu-modules-aws-fargate-service` module, since `otel_collector_version` isn't exposed until `1.14.0`.
- Bumps the module ref from `1.6.1` to `1.14.0`. No variables were removed/renamed since `1.6.1` (diff is additive/optional only), but the bump does force:
  - replacement of the ALB/task security groups (the module now sets an explicit `description` on the endpoint SG, which is immutable and forces recreation)
  - replacement of the ECS task execution IAM role (renamed for a character-length validation fix)
  - in-place updates to the ALB listener SSL policy and ECS Container Insights setting

## Why split from the otel pin
The first attempt at this PR included `otel_collector_version = "v0.49.0"` in the same commit, and applying it to staging failed with `Task failed ELB health checks`. The security-group/IAM churn above happens in the same apply as the ECS task rollout, and is the most likely cause — not the otel image tag itself. Landing the module bump on its own first lets us verify the SG/IAM replacement is stable in staging before pinning the collector version in a follow-up PR.

## Test plan
- [x] `tofu validate` passes for `staging` and `prod` configs
- [ ] `tofu plan`/apply reviewed and confirmed stable in staging (no ELB health check failures)
- [ ] Follow-up PR pins `otel_collector_version = "v0.49.0"` once this is verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)