### PR TITLE
fix(security): enforce SSL for RDS PostgreSQL connections

### DIFF
--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -31,6 +31,11 @@ resource "aws_db_parameter_group" "main" {
     value = "1"
   }
 
+  parameter {
+    name  = "rds.force_ssl"
+    value = "1"
+  }
+
   tags = {
     Name = "${var.project_name}-${var.environment}-parameter-group"
   }


### PR DESCRIPTION
## Summary
- Sets `rds.force_ssl = 1` on the `aws_db_parameter_group`, so the DB rejects plaintext connections.

## TODO
- Update current database connection in app to use SSL or IAM auth (includes SSL).

## Important: manual follow-up required
`rds.force_ssl` is a **static** parameter for the `postgres14` family. Applying this Terraform change updates the parameter group but does **not** take effect on the running instance until it's rebooted. After merge/apply, the RDS instance needs an explicit reboot (ideally during a maintenance window) for enforcement to actually kick in.

## Test plan
- [x] `tofu validate` passes for `staging` and `prod` configs
- [ ] `tofu plan` reviewed before merge/apply
- [ ] Reboot RDS instance (staging, then prod) during a maintenance window after apply
- [ ] Confirm Vanta test passes after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)